### PR TITLE
add IP whitelisting

### DIFF
--- a/helpers/network_helper.py
+++ b/helpers/network_helper.py
@@ -1,0 +1,30 @@
+import logging
+
+from flask import abort
+from ipaddress import IPv4Address, IPv4Network
+
+
+log = logging.getLogger(__name__)
+
+
+def _ip_allowed(ip, networks):
+    """Returns True if ip is in any of the networks, False otherwise"""
+    # If no CIDRs are defined, all IPs are allowed
+    ip_allowed = not networks
+
+    ip = IPv4Address(ip)
+
+    for network in networks:
+        if ip in network:
+            ip_allowed = True
+            break
+
+    return ip_allowed
+
+
+def check_ip_is_authorized(ip, networks):
+    if not _ip_allowed(ip, networks):
+        log.info(f"Rejecting request from unauthorized IP {ip}")
+        abort(401)
+
+    log.info(f"Accepted request from {ip}")

--- a/helpers/network_helper.py
+++ b/helpers/network_helper.py
@@ -1,7 +1,7 @@
 import logging
 
 from flask import abort
-from ipaddress import IPv4Address, IPv4Network
+from ipaddress import IPv4Address
 
 
 log = logging.getLogger(__name__)


### PR DESCRIPTION
This adds the ability to whitelist CIDRs as requested in https://github.com/eniklas/gamatrix-gog/issues/21. If CIDRs are defined, access will only be allowed if the requesting IP is in one of the allowed CIDRs. For example, if the config file only allows requests from localhost:

```
allowed_cidrs:
  - 127.0.0.1/32
```

Then only 127.0.0.1 will be able to access the web site:
```
INFO:helpers.network_helper:Rejecting request from unauthorized IP 192.168.1.100
INFO:helpers.network_helper:Accepted request from 127.0.0.1
```
