### PR TITLE
Enable tests and test cmdline -> config file processing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,6 @@ jobs:
         python -m black --check .
 
     - name: Test with pytest
-      if: false # not ready yet, once we have tests, remove this line.
       run: |
-        python -m pytest --cov
+        python -m pytest
       

--- a/.vscode/recommended.settings.json
+++ b/.vscode/recommended.settings.json
@@ -4,5 +4,8 @@
     "editor.formatOnSave": true,
     "python.testing.pytestEnabled": true,
     "python.linting.flake8Enabled": true,
-    "python.linting.mypyEnabled": true
+    "python.linting.mypyEnabled": true,
+    "python.testing.pytestArgs": [],
+    "python.testing.unittestEnabled": false,
+    "python.testing.nosetestsEnabled": false
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # gamatrix-gog
 
-[![CI](https://github.com/eniklas/gamatrix-gog/actions/workflows/ci.yml/badge.svg)](https://github.com/eniklas/gamatrix-gog/actions/workflows/ci.yml)
+[![CI](https://github.com/eniklas/gamatrix-gog/actions/workflows/ci.yml/badge.svg?branch=master&event=push)](https://github.com/eniklas/gamatrix-gog/actions/workflows/ci.yml)
 
 ## Quick start
 

--- a/config-sample.yaml
+++ b/config-sample.yaml
@@ -8,7 +8,7 @@ mode: server
 # The network interface to use when running in server mode
 interface: 0.0.0.0
 # The network port to use when running in server mode
-port: 80
+port: 8080
 
 # IGDB client setup
 # Instructions for how to obtain a client ID & secret can be found here: https://api-docs.igdb.com/#about

--- a/gamatrix-gog.py
+++ b/gamatrix-gog.py
@@ -3,7 +3,7 @@ import argparse
 import logging
 import os
 import sys
-from typing import Any, Dict, List
+from typing import Any, List
 
 from flask import Flask, render_template, request
 from ipaddress import IPv4Network

--- a/gamatrix-gog.py
+++ b/gamatrix-gog.py
@@ -320,10 +320,8 @@ if __name__ == "__main__":
         log.setLevel(logging.DEBUG)
 
     # in case we want to see our command line shenanigans in a vebose session:
-    log.debug("Command line arguments:")
-    log.debug(sys.argv)
-    log.debug("Arguments after parsing:")
-    log.debug(args)
+    log.debug(f"Command line arguments: {sys.argv}")
+    log.debug(f"Arguments after parsing: {args}")
 
     try:
         config = build_config(args)

--- a/gamatrix-gog.py
+++ b/gamatrix-gog.py
@@ -3,8 +3,10 @@ import argparse
 import logging
 import os
 import sys
+from typing import Any, Dict, List
 
 from flask import Flask, render_template, request
+import pytest
 from ruamel.yaml import YAML
 
 from helpers.cache_helper import Cache
@@ -241,10 +243,7 @@ def set_max_players(game_list, cache):
         game_list[k]["max_players"] = max_players
 
 
-if __name__ == "__main__":
-    logging.basicConfig(level=logging.INFO)
-    log = logging.getLogger()
-
+def parse_cmdline(argv: List[str]) -> Any:
     parser = argparse.ArgumentParser(description="Show games owned by multiple users.")
     parser.add_argument(
         "db", type=str, nargs="*", help="the GOG DB for a user; multiple can be listed"
@@ -291,9 +290,23 @@ if __name__ == "__main__":
         help="Show games with unknown max players",
     )
 
-    args = parser.parse_args()
+    return parser.parse_args(argv)
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    log = logging.getLogger()
+
+    args = parse_cmdline(sys.argv[1:])
+
     if args.debug:
         log.setLevel(logging.DEBUG)
+
+    # in case we want to see our command line shenanigans in a vebose session:
+    log.debug("Command line arguments:")
+    log.debug(sys.argv)
+    log.debug("Arguments after parsing:")
+    log.debug(args)
 
     try:
         config = build_config(args)

--- a/helpers/constants.py
+++ b/helpers/constants.py
@@ -1,6 +1,6 @@
 import re
 
-ALPHANUM_PATTERN = re.compile("[^\s\w]+")
+ALPHANUM_PATTERN = re.compile(r"[^\s\w]+")
 
 # Full mapping is at https://api-docs.igdb.com/#external-game-enums,
 # but only steam actually works; the other platforms' IDs don't match

--- a/test_cmdline.py
+++ b/test_cmdline.py
@@ -1,0 +1,91 @@
+"""Test for command line switches affecting the config.
+
+Currently, these are the values you can affect via the command line:
+
+mode: client | server # default is client, use -s
+interface: (valid interface address) # default is 0.0.0.0, use -i
+port: (valid port) # default is 8080, use -p
+include_single_player: True | False # use -I
+"""
+
+from typing import Any, List
+
+import pytest
+
+gog = __import__("gamatrix-gog")
+
+
+@pytest.mark.parametrize(
+    "description,commandline,config_fields,expected_values",
+    [
+        [
+            "No switches",  # Description, should this test pass fail.
+            [
+                "./gamatrix-gog.py",  # standard, just left here to simulate actual command line argv list...
+                "--config-file",  # use long switch names, more descriptive this way
+                "./config-sample.yaml",  # use the sample yaml as a test data source
+            ],
+            [
+                "mode",  # names of the top-level field in the config file, in this case mode
+                "interface",
+                "port",
+                "include_single_player",
+                "all_games",
+            ],
+            [
+                "server",  # values that are expected, this list is arranged to coincide with fields in the same order as the list above
+                "0.0.0.0",
+                8080,
+                False,
+                False,
+            ],
+        ],
+        [
+            "Assorted values all in one",
+            [
+                "./gamatrix-gog.py",  # just here to simulate actual command line argv list...
+                "--config-file",
+                "./config-sample.yaml",
+                "--server",
+                "--interface",
+                "1.2.3.4",
+                "--port",
+                "62500",
+                "--include-single-player",
+                "--all-games",
+            ],
+            ["mode", "interface", "port", "include_single_player", "all_games"],
+            [
+                "server",
+                "1.2.3.4",
+                62500,
+                True,
+                True,
+            ],
+        ],
+        [
+            "Only set the mode to server",
+            [
+                "./gamatrix-gog.py",
+                "--config-file",
+                "./config-sample.yaml",
+                "--server",
+            ],
+            ["mode"],
+            ["server"],
+        ],
+    ],
+)
+def test_cmdline_handling(
+    description: str,
+    commandline: List[str],
+    config_fields: List[str],
+    expected_values: List[Any],
+):
+    """Parse the command line and build the config file, checking for problems."""
+    args = gog.parse_cmdline(commandline)
+    config = gog.build_config(args)
+    for i in range(len(config_fields)):
+        assert (
+            config[config_fields[i]] == expected_values[i]
+        ), f"Failure for pass: '{description}'"


### PR DESCRIPTION
To enable testing, let's ensure our process from command-line to runtime-config has some clear tests in place.

_(This will aid in any move from `argparse` to other command-line parsers later)_

Note that in the course of doing this work, a few new issues were raised!
- #34
- #35
- #36
- #37
- #38
