### PR TITLE
Interim change to switch argparse out for docopt

### DIFF
--- a/gamatrix-gog.py
+++ b/gamatrix-gog.py
@@ -3,7 +3,7 @@ import argparse
 import logging
 import os
 import sys
-from typing import Any, List
+from typing import Any, Dict, List
 
 from flask import Flask, render_template, request
 from ipaddress import IPv4Network

--- a/gamatrix-gog.py
+++ b/gamatrix-gog.py
@@ -3,7 +3,7 @@ import argparse
 import logging
 import os
 import sys
-from typing import Any, Dict, List
+from typing import Any, List
 
 from flask import Flask, render_template, request
 from ipaddress import IPv4Network

--- a/gamatrix-gog.py
+++ b/gamatrix-gog.py
@@ -6,12 +6,12 @@ Show and compare between games owned by multiple users.
 Usage:
     gamatrix-gog.py --help
     gamatrix-gog.py --version
-    gamatrix-gog.py [--config-file=CFG] [--debug] [--all-games] [--interface=IFC] [--include-single-player] [--port=PORT] [--server] [--userid=UID ...] [--include-zero-players] [<db> ... ]
+    gamatrix-gog.py [--config-file=CFG] [--debug] [--all-games] [--interface=IFC] [--include-single-player] [--port=PORT] [--server] [--userid=UID ...] [<db> ... ]
 
 Options:
   -h, --help                   show this help message and exit
   -v, --version                print version and exit
-  -c CFG --config-file=CFG     the config file to use
+  -c CFG, --config-file=CFG    the config file to use
   -d, --debug                  debug output
   -a, --all-games              list all games owned by the selected users (doesn't include single player unless -I is used)
   -i IFC, --interface=IFC      the network interface to use if running in server mode; default is 0.0.0.0.
@@ -19,7 +19,6 @@ Options:
   -p PORT, --port=PORT         the network port to use if running in server mode; default is 8080.
   -s, --server                 run in server mode
   -u USERID, --userid=USERID   the GOG user IDs to compare, there can be multiples of this switch
-  -z, --include-zero-players   show games with unknown max players
 
 Positional Arguments:
   <db>                         the GOG DB for a user, multiple can be listed
@@ -390,7 +389,9 @@ def set_multiplayer_status(game_list, cache):
 
 
 def parse_cmdline(argv: List[str]) -> Dict[str, object]:
-    return docopt.docopt(__doc__, help=True, version=VERSION, options_first=True)
+    return docopt.docopt(
+        __doc__, argv=argv, help=True, version=VERSION, options_first=True
+    )
 
 
 def OLD_parse_cmdline(argv: List[str]) -> Any:
@@ -447,7 +448,7 @@ if __name__ == "__main__":
 
     args = OLD_parse_cmdline(sys.argv[1:])
     print("OLD DONE")
-    opts = parse_cmdline(sys.argv)
+    opts = parse_cmdline(sys.argv[1:])
     print("NEW DONE")
 
     print("+OLD COMMANDLINE+++++++++++++++++++++++++")

--- a/gamatrix-gog.py
+++ b/gamatrix-gog.py
@@ -1,10 +1,38 @@
 #!/usr/bin/env python3
+"""
+gamatrix-gog
+Show and compare between games owned by multiple users.
+
+Usage:
+    gamatrix-gog.py --help
+    gamatrix-gog.py --version
+    gamatrix-gog.py [--config-file=CFG] [--debug] [--all-games] [--interface=IFC] [--include-single-player] [--port=PORT] [--server] [--userid=UID ...] [--include-zero-players] [<db> ... ]
+
+Options:
+  -h, --help                   show this help message and exit
+  -v, --version                print version and exit
+  -c CFG --config-file=CFG     the config file to use
+  -d, --debug                  debug output
+  -a, --all-games              list all games owned by the selected users (doesn't include single player unless -I is used)
+  -i IFC, --interface=IFC      the network interface to use if running in server mode; default is 0.0.0.0.
+  -I, --include-single-player  include single player games
+  -p PORT, --port=PORT         the network port to use if running in server mode; default is 8080.
+  -s, --server                 run in server mode
+  -u USERID, --userid=USERID   the GOG user IDs to compare, there can be multiples of this switch
+  -z, --include-zero-players   show games with unknown max players
+
+Positional Arguments:
+  <db>                         the GOG DB for a user, multiple can be listed
+"""
+
 import argparse
+import json
 import logging
 import os
 import sys
-from typing import Any, List
+from typing import Any, Dict, List
 
+import docopt
 from flask import Flask, render_template, request
 from ipaddress import IPv4Network
 from ruamel.yaml import YAML
@@ -103,7 +131,102 @@ def init_opts():
     }
 
 
-def build_config(args):
+def build_config(args: Dict[str, Any]) -> Dict[str, Any]:
+    """Returns a config dict created from the config file and
+    command-line arguments, with the latter taking precedence
+    """
+    if args.get("--config-file", None) is not None:
+        yaml = YAML(typ="safe")
+        with open(args["--config-file"], "r") as config_file:
+            config = yaml.load(config_file)
+    else:
+        # We didn't get a config file, so populate from args
+        config = {}
+
+    # TODO: allow using both IDs and DBs (use one arg and detect if it's an int)
+    # TODO: should be able to use unambiguous partial names
+    if not args.get("<db>", []) and "users" not in config:
+        raise ValueError("You must use -u, have users in the config file, or list DBs")
+
+    # Command-line args override values in the config file
+    # TODO: maybe we can do this directly in argparse, or otherwise better
+
+    # This can't be given as an argument as it wouldn't make much sense;
+    #  provide a sane default if it's missing from the config file
+    if "db_path" not in config:
+        config["db_path"] = "."
+
+    config["all_games"] = args.get("--all-games", False)
+
+    config["include_single_player"] = args.get("--include-single-player", False)
+
+    if args.get("--server", True):  # Note that the --server opt is False unless present
+        config["mode"] = "server"
+
+    if args.get("--interface"):
+        config["interface"] = args["--interface"]
+    if "interface" not in config:
+        config["interface"] = "0.0.0.0"
+
+    if args.get("--port"):
+        config["port"] = int(args["--port"])
+    if "port" not in config:
+        config["port"] = 8080
+
+    # DBs and user IDs can be in the config file and/or passed in as args
+    config["db_list"] = []
+    if "users" not in config:
+        config["users"] = {}
+
+    for userid in config["users"]:
+        config["db_list"].append(
+            "{}/{}".format(config["db_path"], config["users"][userid]["db"])
+        )
+
+    for db in args.get("<db>", []):
+        if os.path.abspath(db) not in config["db_list"]:
+            config["db_list"].append(os.path.abspath(db))
+
+    print(">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>")
+    print(config["users"])
+    print(">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>")
+
+    for userid_str in args.get("--userid", []):
+        userid = int(userid_str)
+        if userid not in config["users"]:
+            raise ValueError(
+                "User ID {} isn't defined in the config file".format(userid)
+            )
+        elif "db" not in config["users"][userid]:
+            raise ValueError(
+                "User ID {} is missing the db key in the config file".format(userid)
+            )
+        elif (
+            "{}/{}".format(config["db_path"], config["users"][userid]["db"])
+            not in config["db_list"]
+        ):
+            config["db_list"].append(
+                "{}/{}".format(config["db_path"], config["users"][userid]["db"])
+            )
+
+    if "hidden" not in config:
+        config["hidden"] = []
+
+    # Lowercase and remove non-alphanumeric characters for better matching
+    for i in range(len(config["hidden"])):
+        config["hidden"][i] = ALPHANUM_PATTERN.sub("", config["hidden"][i]).lower()
+
+    sanitized_metadata = {}
+    for title in config["metadata"]:
+        sanitized_title = ALPHANUM_PATTERN.sub("", title).lower()
+        sanitized_metadata[sanitized_title] = config["metadata"][title]
+
+    config["metadata"] = sanitized_metadata
+
+    return config
+
+
+def OLD_build_config(args):
     """Returns a config dict created from the config file and
     command-line arguments, with the latter taking precedence
     """
@@ -266,7 +389,11 @@ def set_multiplayer_status(game_list, cache):
         game_list[k]["max_players"] = max_players
 
 
-def parse_cmdline(argv: List[str]) -> Any:
+def parse_cmdline(argv: List[str]) -> Dict[str, object]:
+    return docopt.docopt(__doc__, help=True, version=VERSION, options_first=True)
+
+
+def OLD_parse_cmdline(argv: List[str]) -> Any:
     parser = argparse.ArgumentParser(description="Show games owned by multiple users.")
     parser.add_argument(
         "db", type=str, nargs="*", help="the GOG DB for a user; multiple can be listed"
@@ -314,7 +441,31 @@ if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO)
     log = logging.getLogger()
 
-    args = parse_cmdline(sys.argv[1:])
+    print("=========================================")
+    print(sys.argv)
+    print("=========================================")
+
+    args = OLD_parse_cmdline(sys.argv[1:])
+    print("OLD DONE")
+    opts = parse_cmdline(sys.argv)
+    print("NEW DONE")
+
+    print("+OLD COMMANDLINE+++++++++++++++++++++++++")
+    print(args)
+
+    print("/NEW COMMANDLINE/////////////////////////")
+    print(opts)
+
+    OLD_config = OLD_build_config(args)
+    config = build_config(opts)
+
+    with open("old_config.json", "w") as of_:
+        of_.write(json.dumps(OLD_config))
+
+    with open("new_config.json", "w") as nf_:
+        nf_.write(json.dumps(config))
+
+    exit()
 
     if args.debug:
         log.setLevel(logging.DEBUG)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,8 @@
-click==7.1.2
+docopt
 Flask==1.1.2
-itsdangerous==1.1.0
 Jinja2==2.11.2
 MarkupSafe==1.1.1
 pyyaml==5.3.1
 requests==2.25.1
 ruamel.yaml==0.16.12
 ruamel.yaml.clib==0.2.2
-Werkzeug==1.0.1

--- a/test_cmdline.py
+++ b/test_cmdline.py
@@ -6,6 +6,7 @@ mode: client | server # default is client, use -s
 interface: (valid interface address) # default is 0.0.0.0, use -i
 port: (valid port) # default is 8080, use -p
 include_single_player: True | False # use -I
+all_games: True | False # use -a
 """
 
 from typing import Any, List
@@ -13,6 +14,56 @@ from typing import Any, List
 import pytest
 
 gog = __import__("gamatrix-gog")
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        [
+            "./gamatrix-gog.py",  # standard, just left here to simulate actual command line argv list...
+            "--config-file",  # use long switch names, more descriptive this way
+            "./config-sample.yaml",  # use the sample yaml as a test data source
+        ],
+        [
+            "./gamatrix-gog.py",  # standard, just left here to simulate actual command line argv list...
+            "--config-file",  # use long switch names, more descriptive this way
+            "./config-sample.yaml",  # use the sample yaml as a test data source
+            "--include-single-player",
+            "--server",
+            "--port=666",
+            "--interface=1.22.3.44",
+            "--all-games",
+        ],
+    ],
+)
+def test_old_vs_new(argv):
+    print("=========================================")
+    print(argv)
+    print("=========================================")
+
+    args = gog.OLD_parse_cmdline(argv[1:])
+    print("OLD DONE")
+    opts = gog.parse_cmdline(argv[1:])
+    print("NEW DONE")
+
+    print("+OLD COMMANDLINE+++++++++++++++++++++++++")
+    print(args)
+
+    print("/NEW COMMANDLINE/////////////////////////")
+    print(opts)
+
+    og_config = gog.OLD_build_config(args)
+    config = gog.build_config(opts)
+
+    fields = ["mode", "port", "interface", "include_single_player", "all_games"]
+    for field in fields:
+        assert og_config[field] == config[field]
+
+    # with open("old_config.json", "w") as of_:
+    #     of_.write(json.dumps(OLD_config))
+
+    # with open("new_config.json", "w") as nf_:
+    #     nf_.write(json.dumps(config))
 
 
 @pytest.mark.parametrize(
@@ -83,7 +134,83 @@ def test_cmdline_handling(
     expected_values: List[Any],
 ):
     """Parse the command line and build the config file, checking for problems."""
-    args = gog.parse_cmdline(commandline)
+    args = gog.OLD_parse_cmdline(commandline)
+    config = gog.OLD_build_config(args)
+    for i in range(len(config_fields)):
+        assert (
+            config[config_fields[i]] == expected_values[i]
+        ), f"Failure for pass: '{description}'"
+
+
+@pytest.mark.parametrize(
+    "description,commandline,config_fields,expected_values",
+    [
+        [
+            "No switches",  # Description, should this test pass fail.
+            [
+                "./gamatrix-gog.py",  # standard, just left here to simulate actual command line argv list...
+                "--config-file",  # use long switch names, more descriptive this way
+                "./config-sample.yaml",  # use the sample yaml as a test data source
+            ],
+            [
+                "mode",  # names of the top-level field in the config file, in this case mode
+                "interface",
+                "port",
+                "include_single_player",
+                "all_games",
+            ],
+            [
+                "server",  # values that are expected, this list is arranged to coincide with fields in the same order as the list above
+                "0.0.0.0",
+                8080,
+                False,
+                False,
+            ],
+        ],
+        [
+            "Assorted values all in one",
+            [
+                "./gamatrix-gog.py",  # just here to simulate actual command line argv list...
+                "--config-file",
+                "./config-sample.yaml",
+                "--server",
+                "--interface",
+                "1.2.3.4",
+                "--port",
+                "62500",
+                "--include-single-player",
+                "--all-games",
+            ],
+            ["mode", "interface", "port", "include_single_player", "all_games"],
+            [
+                "server",
+                "1.2.3.4",
+                62500,
+                True,
+                True,
+            ],
+        ],
+        [
+            "Only set the mode to server",
+            [
+                "./gamatrix-gog.py",
+                "--config-file",
+                "./config-sample.yaml",
+                "--server",
+            ],
+            ["mode"],
+            ["server"],
+        ],
+    ],
+)
+def test_new_cmdline_handling(
+    description: str,
+    commandline: List[str],
+    config_fields: List[str],
+    expected_values: List[Any],
+):
+    """Parse the command line and build the config file, checking for problems."""
+    args = gog.parse_cmdline(commandline[1:])
     config = gog.build_config(args)
     for i in range(len(config_fields)):
         assert (


### PR DESCRIPTION
**NOTE**: Interim PR - not intended to merge.

This is to prove to myself and to others that it will work without breaking everything.

Do have a look and point out where I might be missing important details!

Left all the `argparse` stuff in and added the `docopt` stuff alongside it. Then tested the outcome of `build_config` for each path to compare.

You can see the doc in the header of `gamatrix-gog.py` which essentially is exactly the output you want from `--help`.

The tests essentially pass in simulated command lines (as `sys.argv` lists) and then build a config from the options recieved. Then the fields within the config are compared between old and new.