### PR TITLE
handle unknown platforms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,6 @@ dmypy.json
 # User's config file
 config.yaml
 .cache.json
+
+# Static files for flask, these are tracked in gamatrix-gog-configs
+static/

--- a/gamatrix-gog.py
+++ b/gamatrix-gog.py
@@ -89,6 +89,7 @@ def compare_libraries():
         users=opts["user_ids_to_compare"],
         caption=gog.get_caption(len(common_games)),
         show_keys=opts["show_keys"],
+        platforms=PLATFORMS,
     )
 
 

--- a/gamatrix-gog.py
+++ b/gamatrix-gog.py
@@ -14,6 +14,7 @@ from helpers.constants import (
     ALPHANUM_PATTERN,
     IGDB_GAME_MODE,
     IGDB_MULTIPLAYER_GAME_MODES,
+    PLATFORMS,
 )
 from helpers.gogdb_helper import gogDB
 from helpers.igdb_helper import IGDBHelper
@@ -30,7 +31,7 @@ def root():
     return render_template(
         "index.html",
         users=config["users"],
-        platforms=["epic", "gog", "origin", "steam", "uplay", "xboxone"],
+        platforms=PLATFORMS,
         version=VERSION,
     )
 

--- a/helpers/constants.py
+++ b/helpers/constants.py
@@ -31,3 +31,7 @@ IGDB_MAX_PLAYER_KEYS = [
 ]
 # The API has a rate limit of 4 requests/sec
 IGDB_API_CALL_DELAY = 0.25
+
+# Order matters; when deduping, the release key
+# retained will be the first one in the list
+PLATFORMS = ("steam", "bethesda", "gog", "epic", "origin", "uplay", "xboxone")

--- a/helpers/gogdb_helper.py
+++ b/helpers/gogdb_helper.py
@@ -4,7 +4,7 @@ import logging
 import os
 import sqlite3
 
-from .constants import ALPHANUM_PATTERN
+from .constants import ALPHANUM_PATTERN, PLATFORMS
 from functools import cmp_to_key
 
 
@@ -373,12 +373,16 @@ class gogDB:
         platforms so that steam is first; we prefer the steam key when
         removing dups, as we can currently only get IGDB data for steam
         """
-        platforms = ("steam", "gog", "epic", "origin", "uplay", "xboxone")
+        platforms = PLATFORMS
         title_a = a[1]["sanitized_title"]
         title_b = b[1]["sanitized_title"]
         if title_a == title_b:
             platform_a = a[1]["platforms"][0]
             platform_b = b[1]["platforms"][0]
+            for platform in [platform_a, platform_b]:
+                if platform not in platforms:
+                    self.log.warning(f"Unknown platform {platform}, not sorting")
+                    return 0
             index_a = platforms.index(platform_a)
             index_b = platforms.index(platform_b)
             if index_a < index_b:

--- a/templates/game_list.html
+++ b/templates/game_list.html
@@ -57,7 +57,11 @@
                 {%- endif -%}
                 <div style="float:right">
                     {% for platform in value.platforms -%}
+                    {%- if platform not in platforms -%}
+                    <img src="/static/question_block.jpg" width="20" height="20">&nbsp;
+                    {%- else -%}
                     <img src="/static/{{ platform }}.png" width="20" height="20">&nbsp;
+                    {%- endif -%}
                     {%- endfor -%}
                 </div>
             </td>

--- a/templates/index.html
+++ b/templates/index.html
@@ -57,7 +57,7 @@
             </tr>
             <tr>
                 <td colspan="3">
-                    <div style="width:250px; margin: 0 auto;">
+                    <div style="width:300px; margin: 0 auto;">
                         <p style="text-align: center;">
                         <table width="100%">
                             <td colspan="2">Exclude platforms:</td>
@@ -66,7 +66,8 @@
                                 {%- for platform in batch %}
                                 <td>
                                     <input type="checkbox" id="{{ platform }}" name="exclude_platform_{{ platform }}">
-                                    <label for="{{ platform }}">{{ platform|capitalize }}</label>
+                                    <label for="{{ platform }}"><img src="/static/{{ platform }}.png" width="20"
+                                            height="20">&nbsp;{{ platform|capitalize }}</label>
                                 </td>
                                 {%- endfor %}
                             </tr>


### PR DESCRIPTION
We got a crash when we ran into a new platform, when a DB included Bethesda games from a new integration. The secondary sort used during dedup couldn't handle that; now it can. Unknown platforms are handled fine now, aside from not being sorted.

This also adds support for Bethesda games and adds the platform logos on the front page.