### PR TITLE
sanitize title in helper

### DIFF
--- a/gamatrix-gog.py
+++ b/gamatrix-gog.py
@@ -11,13 +11,13 @@ from ruamel.yaml import YAML
 
 from helpers.cache_helper import Cache
 from helpers.constants import (
-    ALPHANUM_PATTERN,
     IGDB_GAME_MODE,
     IGDB_MULTIPLAYER_GAME_MODES,
     PLATFORMS,
 )
 from helpers.gogdb_helper import gogDB
 from helpers.igdb_helper import IGDBHelper
+from helpers.misc_helper import sanitize_title
 from helpers.network_helper import check_ip_is_authorized
 from version import VERSION
 
@@ -210,11 +210,11 @@ def build_config(args):
 
     # Lowercase and remove non-alphanumeric characters for better matching
     for i in range(len(config["hidden"])):
-        config["hidden"][i] = ALPHANUM_PATTERN.sub("", config["hidden"][i]).lower()
+        config["hidden"][i] = sanitize_title(config["hidden"][i])
 
     sanitized_metadata = {}
     for title in config["metadata"]:
-        sanitized_title = ALPHANUM_PATTERN.sub("", title).lower()
+        sanitized_title = sanitize_title(title)
         sanitized_metadata[sanitized_title] = config["metadata"][title]
 
     config["metadata"] = sanitized_metadata

--- a/helpers/constants.py
+++ b/helpers/constants.py
@@ -1,7 +1,3 @@
-import re
-
-ALPHANUM_PATTERN = re.compile(r"[^\s\w]+")
-
 # Full mapping is at https://api-docs.igdb.com/#external-game-enums,
 # but only steam actually works; the other platforms' IDs don't match
 # what's in IGDB

--- a/helpers/gogdb_helper.py
+++ b/helpers/gogdb_helper.py
@@ -4,7 +4,8 @@ import logging
 import os
 import sqlite3
 
-from .constants import ALPHANUM_PATTERN, PLATFORMS
+from .constants import PLATFORMS
+from helpers.misc_helper import sanitize_title
 from functools import cmp_to_key
 
 
@@ -165,7 +166,7 @@ class gogDB:
                     if release_key not in game_list:
                         # This is the first we've seen this title, so add it
                         title = json.loads(title_json)["title"]
-                        sanitized_title = ALPHANUM_PATTERN.sub("", title).lower()
+                        sanitized_title = sanitize_title(title)
                         if sanitized_title in self.config["hidden"]:
                             self.log.debug(
                                 f"{release_key} ({title}): skipping as it's hidden"

--- a/helpers/misc_helper.py
+++ b/helpers/misc_helper.py
@@ -1,0 +1,16 @@
+import logging
+import re
+
+log = logging.getLogger(__name__)
+
+
+def sanitize_title(title):
+    """Returns title without any special characters"""
+    alphanum_pattern = re.compile(r"[^\s\w]+")
+
+    sanitized_title = alphanum_pattern.sub("", title).lower()
+    if not sanitized_title:
+        log.warning(f"Sanitizing {title} yielded an empty string")
+        sanitized_title = " "
+
+    return sanitized_title

--- a/version.py
+++ b/version.py
@@ -1,1 +1,1 @@
-VERSION = "1.1.0"
+VERSION = "1.1.1"


### PR DESCRIPTION
We were sanitizing titles in a few places, so I moved that into a helper function. An empty sanitized title is now handled as well; I've never run into that, but if a title is composed purely of non-alphanumeric characters and no whitespace, it would happen.