### PR TITLE
handle api failures gracefully

### DIFF
--- a/gamatrix-gog.py
+++ b/gamatrix-gog.py
@@ -67,6 +67,9 @@ def compare_libraries():
 
     common_games = gog.get_common_games()
 
+    if not igdb.access_token:
+        igdb.get_access_token()
+
     for release_key in list(common_games.keys()):
         igdb.get_igdb_id(release_key)
         igdb.get_game_info(release_key)
@@ -370,7 +373,6 @@ if __name__ == "__main__":
     gog = gogDB(config, opts)
     common_games = gog.get_common_games()
 
-    # TODO: handle not getting an access token
     for release_key in list(common_games.keys()):
         igdb.get_igdb_id(release_key)
         igdb.get_game_info(release_key)


### PR DESCRIPTION
This adds graceful handling of IGDB API failures. When we fail to get an access token, any further requests will be skipped until we try again (which we do once every time the user clicks `Giv'er`). When we have a valid access token but other requests fail, they'll just return an empty response and not block or cause the script to fail.