### PR TITLE
add --update-cache option

### DIFF
--- a/gamatrix-gog.py
+++ b/gamatrix-gog.py
@@ -211,6 +211,10 @@ def build_config(args):
     if "hidden" not in config:
         config["hidden"] = []
 
+    config["update_cache"] = False
+    if args.update_cache:
+        config["update_cache"] = True
+
     # Lowercase and remove non-alphanumeric characters for better matching
     for i in range(len(config["hidden"])):
         config["hidden"][i] = sanitize_title(config["hidden"][i])
@@ -320,6 +324,12 @@ def parse_cmdline(argv: List[str]) -> Any:
         "-u", "--userid", type=int, nargs="*", help="the GOG user IDs to compare"
     )
     parser.add_argument(
+        "-U",
+        "--update-cache",
+        action="store_true",
+        help="update cache entries that have incomplete info",
+    )
+    parser.add_argument(
         "-v", "--version", action="store_true", help="print version and exit"
     )
 
@@ -374,9 +384,9 @@ if __name__ == "__main__":
     common_games = gog.get_common_games()
 
     for release_key in list(common_games.keys()):
-        igdb.get_igdb_id(release_key)
-        igdb.get_game_info(release_key)
-        igdb.get_multiplayer_info(release_key)
+        igdb.get_igdb_id(release_key, config["update_cache"])
+        igdb.get_game_info(release_key, config["update_cache"])
+        igdb.get_multiplayer_info(release_key, config["update_cache"])
 
     cache.save()
     set_multiplayer_status(common_games, cache.data)

--- a/helpers/igdb_helper.py
+++ b/helpers/igdb_helper.py
@@ -140,14 +140,16 @@ class IGDBHelper:
                 self.api_failures += 1
                 return {}
 
-    def get_game_info(self, release_key):
+    def get_game_info(self, release_key, update=False):
         """Gets some game info for release_key.
         Returns True on success, False on failure
         """
         if release_key not in self.cache["igdb"]["games"]:
             self.log.error(f"{release_key} not in cache; use get_igdb_id() first")
             return False
-        elif "info" in self.cache["igdb"]["games"][release_key]:
+        elif "info" in self.cache["igdb"]["games"][release_key] and not (
+            update and not self.cache["igdb"]["games"][release_key]["info"]
+        ):
             self.log.debug(f"Found game info for {release_key} in cache")
             return True
         elif "igdb_id" not in self.cache["igdb"]["games"][release_key]:
@@ -164,11 +166,13 @@ class IGDBHelper:
         self.cache["igdb"]["games"][release_key]["info"] = response
         return True
 
-    def get_igdb_id(self, release_key):
+    def get_igdb_id(self, release_key, update=False):
         """Gets the IDGB ID for release_key"""
         if release_key not in self.cache["igdb"]["games"]:
             self.cache["igdb"]["games"][release_key] = {}
-        elif "igdb_id" in self.cache["igdb"]["games"][release_key]:
+        elif "igdb_id" in self.cache["igdb"]["games"][release_key] and not (
+            update and self.cache["igdb"]["games"][release_key]["igdb_id"] == 0
+        ):
             self.log.debug(
                 "Found IGDB ID {} for {} in cache".format(
                     self.cache["igdb"]["games"][release_key]["igdb_id"], release_key
@@ -202,7 +206,7 @@ class IGDBHelper:
             self.log.debug(f"{release_key} not found in IGDB, setting ID to 0")
             self.cache["igdb"]["games"][release_key]["igdb_id"] = 0
 
-    def get_multiplayer_info(self, release_key):
+    def get_multiplayer_info(self, release_key, update=False):
         """Gets the multiplayer info for release_key.
         Returns True on success, False on failure
         """
@@ -210,7 +214,9 @@ class IGDBHelper:
             self.log.error(f"{release_key} not in cache; use get_igdb_id() first")
             return False
 
-        elif "max_players" in self.cache["igdb"]["games"][release_key]:
+        elif "max_players" in self.cache["igdb"]["games"][release_key] and not (
+            update and self.cache["igdb"]["games"][release_key]["max_players"] == 0
+        ):
             self.log.debug(
                 "Found max players {} for release key {} in cache".format(
                     self.cache["igdb"]["games"][release_key]["max_players"],


### PR DESCRIPTION
This adds a `-U/--update-cache` option to the CLI that will refresh the data from IGDB if a title in the cache:
- has an IGDB ID of 0
- has an empty `"info"` field
- has `max_players` of 0 from IGDB