### PR TITLE
add tooltip for user profile pics

### DIFF
--- a/templates/game_list.html
+++ b/templates/game_list.html
@@ -78,7 +78,8 @@
                 {%- else -%}
                 {% for userid in value.installed -%}
                 {% if users[userid]['pic'] is defined -%}
-                <img src="/static/{{ users[userid]['pic'] }}" width="20" height="20">&nbsp;
+                <img src="/static/{{ users[userid]['pic'] }}" width="20" height="20"
+                    title="{{ users[userid]['username'] }}">&nbsp;
                 {%- else -%}
                 {{ users[userid]['username'] }}&nbsp;
                 {%- endif -%}


### PR DESCRIPTION
Adds a tooltip for the profile pics in the installed column per https://github.com/eniklas/gamatrix-gog/issues/59.