### PR TITLE
Use steam or gog key for IGDB data

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,12 @@ Select your search criteria from the front page:
 
 #### Upload DB
 
-Upload a new GOG DB. Only files with a `.db` extension are allowed; the requesting IP is used to identify the uploader and name the target file correctly.
+Upload a new GOG DB. Only files with a `.db` extension are allowed; the requesting IP is used to identify the uploader and name the target file correctly. To upload from a script, you can download [curl for Windows](https://curl.se/windows/) and run the following batch script, replacing `your-gamatrix-gog-url` with your server's DNS name or IP address:
+
+```bat
+curl -F file=@"C:\ProgramData\GOG.com\Galaxy\storage\galaxy-2.0.db" http://<your-gamatrix-gog-url>/compare?option=upload
+pause
+```
 
 #### Game list
 

--- a/gamatrix-gog.py
+++ b/gamatrix-gog.py
@@ -358,7 +358,7 @@ def set_multiplayer_status(game_list, cache):
             log.warning(f"{k}: {reason}")
 
         elif cache["igdb"]["games"][igdb_key]["max_players"] > 0:
-            max_players = cache["igdb"]["games"][k]["max_players"]
+            max_players = cache["igdb"]["games"][igdb_key]["max_players"]
             reason = "from IGDB cache"
             multiplayer = cache["igdb"]["games"][igdb_key]["max_players"] > 1
 

--- a/gamatrix-gog.py
+++ b/gamatrix-gog.py
@@ -136,10 +136,11 @@ def compare_libraries():
     if not igdb.access_token:
         igdb.get_access_token()
 
-    for release_key in list(common_games.keys()):
-        igdb.get_igdb_id(release_key)
-        igdb.get_game_info(release_key)
-        igdb.get_multiplayer_info(release_key)
+    for k in list(common_games.keys()):
+        log.debug(f'{k}: using igdb_key {common_games[k]["igdb_key"]}')
+        igdb.get_igdb_id(common_games[k]["igdb_key"])
+        igdb.get_game_info(common_games[k]["igdb_key"])
+        igdb.get_multiplayer_info(common_games[k]["igdb_key"])
 
     cache.save()
     set_multiplayer_status(common_games, cache.data)
@@ -484,10 +485,11 @@ if __name__ == "__main__":
     gog = gogDB(config, opts)
     common_games = gog.get_common_games()
 
-    for release_key in list(common_games.keys()):
-        igdb.get_igdb_id(release_key, config["update_cache"])
-        igdb.get_game_info(release_key, config["update_cache"])
-        igdb.get_multiplayer_info(release_key, config["update_cache"])
+    for k in list(common_games.keys()):
+        log.debug(f'{k}: using igdb_key {common_games[k]["igdb_key"]}')
+        igdb.get_igdb_id(common_games[k]["igdb_key"], config["update_cache"])
+        igdb.get_game_info(common_games[k]["igdb_key"], config["update_cache"])
+        igdb.get_multiplayer_info(common_games[k]["igdb_key"], config["update_cache"])
 
     cache.save()
     set_multiplayer_status(common_games, cache.data)

--- a/helpers/constants.py
+++ b/helpers/constants.py
@@ -3,10 +3,11 @@ UPLOAD_ALLOWED_EXTENSIONS = ["db"]
 UPLOAD_MAX_SIZE = 100 * 1024 * 1024
 
 # Full mapping is at https://api-docs.igdb.com/#external-game-enums,
-# but only steam actually works; the other platforms' IDs don't match
-# what's in IGDB
+# but only Steam and GOG actually work; the other platforms' IDs
+# don't match what's in IGDB
 IGDB_PLATFORM_ID = {
     "steam": 1,
+    "gog": 5,
 }
 # The mapping of game modes from https://api-docs.igdb.com/#game-mode
 IGDB_GAME_MODE = {

--- a/version.py
+++ b/version.py
@@ -1,1 +1,1 @@
-VERSION = "1.2.0"
+VERSION = "1.2.1"


### PR DESCRIPTION
This changes the IGDB lookups to use the Steam or GOG key for a game from another platform, since those two platforms are the only ones that we can currently get data from (the release keys for other platforms don't match in IGDB).

It turns out the GOG DB has all the release keys for a game, so we pull those out for a non-Steam game, and set the IGDB key to the key for Steam, GOG, or the original key, in that order of preference. So, if we have an Xboxone game that has a Steam key associated with it, the Steam key will be used to query IGDB and determine multiplayer status and max players. This results in 37% of the titles that we previously had no max player data on, now having that data.