### PR TITLE
install libmagic in container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM python:3.9-slim
 
 WORKDIR /usr/src/app
 
+RUN apt update && apt install -y libmagic1 && rm -rf /var/lib/apt/lists/*
 COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 


### PR DESCRIPTION
This is required for `python-magic`.