### PR TITLE
add --installed-only; don't show single player for game grid by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The name comes from [gamatrix](https://github.com/d3r3kk/gamatrix), another tool
 - compares the game libraries of an arbitrary number of users, with several filtering options
 - multiplayer support and max players autopopulated from IGDB when available
 - configuration via YAML file and/or command-line options
-- small (< 150MB) Docker container
+- small (~200MB) Docker container
 - IP whitelisting support
 - ability to upload DBs
 
@@ -77,29 +77,30 @@ The Game grid option shows all games owned by the selected users
 ## Usage
 
 ```pre
-usage: gamatrix-gog.py [-h] [-a] [-c CONFIG_FILE] [-d] [-i INTERFACE] [-I] [-p PORT] [-s] [-u [USERID [USERID ...]]] [db [db ...]]
+gamatrix-gog
+Show and compare between games owned by multiple users.
 
-Show games owned by multiple users.
+Usage:
+    gamatrix-gog.py --help
+    gamatrix-gog.py --version
+    gamatrix-gog.py [--config-file=CFG] [--debug] [--all-games] [--interface=IFC] [--installed-only] [--include-single-player] [--port=PORT] [--server] [--update-cache] [--userid=UID ...] [<db> ... ]
 
-positional arguments:
-  db                    the GOG DB for a user; multiple can be listed
+Options:
+  -h, --help                   Show this help message and exit.
+  -v, --version                Print version and exit.
+  -c CFG, --config-file=CFG    The config file to use.
+  -d, --debug                  Print out verbose debug output.
+  -a, --all-games              List all games owned by the selected users (doesn't include single player unless -S is used).
+  -i IFC, --interface=IFC      The network interface to use if running in server mode; default is 0.0.0.0.
+  -I, --installed-only         Only show games installed by all users.
+  -p PORT, --port=PORT         The network port to use if running in server mode; default is 8080.
+  -s, --server                 Run in server mode.
+  -S, --include-single-player  Include single player games.
+  -U, --update-cache           Update cache entries that have incomplete info.
+  -u USERID, --userid=USERID   The GOG user IDs to compare, there can be multiples of this switch.
 
-optional arguments:
-  -h, --help            show this help message and exit
-  -a, --all-games       list all games owned by the selected users (doesn't include single player unless -I is used)
-  -c CONFIG_FILE, --config-file CONFIG_FILE
-                        the config file to use
-  -d, --debug           debug output
-  -i INTERFACE, --interface INTERFACE
-                        the network interface to use if running in server mode; defaults to 0.0.0.0
-  -I, --include-single-player
-                        Include single player games
-  -p PORT, --port PORT  the network port to use if running in server mode; defaults to 8080
-  -s, --server          run in server mode
-  -u [USERID [USERID ...]], --userid [USERID [USERID ...]]
-                        the GOG user IDs to compare
-  -U, --update-cache    update cache entries that have incomplete info
-  -v, --version         print version and exit
+Positional Arguments:
+  <db>                         The GOG DB for a user, multiple can be listed.
 ```
 
 `db`: a GOG database to use. You can usually find a user's DB in `C:\ProgramData\GOG.com\Galaxy\storage\galaxy-2.0.db`. Multiple DBs can be listed. Not compatible with `-u`.
@@ -110,9 +111,9 @@ optional arguments:
 
 `-d/--debug`: enable debug messages.
 
-`-I/--include-single-player`: include single-player games; by default, only multiplayer games are shown.
-
 `-s/--server`: run in server mode. This will use Flask to serve a small web page where you can select the options you want, and will output the results there.
+
+`-S/--include-single-player`: include single-player games; by default, only multiplayer games are shown.
 
 `-u/--userid`: a list of GOG user IDs to compare. The IDs must be in the [config file](#configuration). You can find the user ID by running `sqlite3 /path/to/galaxy-2.0.db "select * from Users;"`. If you use this option, you can't list DBs; they must be provided for the user IDs in the config file.
 

--- a/gamatrix-gog.py
+++ b/gamatrix-gog.py
@@ -6,18 +6,19 @@ Show and compare between games owned by multiple users.
 Usage:
     gamatrix-gog.py --help
     gamatrix-gog.py --version
-    gamatrix-gog.py [--config-file=CFG] [--debug] [--all-games] [--interface=IFC] [--include-single-player] [--port=PORT] [--server] [--update-cache] [--userid=UID ...] [<db> ... ]
+    gamatrix-gog.py [--config-file=CFG] [--debug] [--all-games] [--interface=IFC] [--installed-only] [--include-single-player] [--port=PORT] [--server] [--update-cache] [--userid=UID ...] [<db> ... ]
 
 Options:
   -h, --help                   Show this help message and exit.
   -v, --version                Print version and exit.
   -c CFG, --config-file=CFG    The config file to use.
   -d, --debug                  Print out verbose debug output.
-  -a, --all-games              List all games owned by the selected users (doesn't include single player unless -I is used).
+  -a, --all-games              List all games owned by the selected users (doesn't include single player unless -S is used).
   -i IFC, --interface=IFC      The network interface to use if running in server mode; default is 0.0.0.0.
-  -I, --include-single-player  Include single player games.
+  -I, --installed-only         Only show games installed by all users.
   -p PORT, --port=PORT         The network port to use if running in server mode; default is 8080.
   -s, --server                 Run in server mode.
+  -S, --include-single-player  Include single player games.
   -U, --update-cache           Update cache entries that have incomplete info.
   -u USERID, --userid=USERID   The GOG user IDs to compare, there can be multiples of this switch.
 
@@ -174,8 +175,7 @@ def compare_libraries():
     set_multiplayer_status(common_games, cache.data)
     common_games = gog.merge_duplicate_titles(common_games)
 
-    if not gog.config["all_games"]:
-        common_games = gog.filter_games(common_games)
+    common_games = gog.filter_games(common_games, gog.config["all_games"])
 
     log.debug(f'user_ids_to_compare = {opts["user_ids_to_compare"]}')
 
@@ -253,8 +253,8 @@ def build_config(args: Dict[str, Any]) -> Dict[str, Any]:
         config["db_path"] = "."
 
     config["all_games"] = args.get("--all-games", False)
-
     config["include_single_player"] = args.get("--include-single-player", False)
+    config["installed_only"] = args.get("--installed-only", False)
 
     if args.get(
         "--server", False
@@ -480,8 +480,7 @@ if __name__ == "__main__":
     set_multiplayer_status(common_games, cache.data)
     common_games = gog.merge_duplicate_titles(common_games)
 
-    if not config["all_games"]:
-        common_games = gog.filter_games(common_games)
+    common_games = gog.filter_games(common_games, config["all_games"])
 
     for key in common_games:
         usernames_with_game_installed = [

--- a/templates/index.html
+++ b/templates/index.html
@@ -39,7 +39,8 @@
                             </div>
                             {% endfor -%}
                             <br>
-                            <div title="Games owned by the selected users, and not owned by unselected users">
+                            <div
+                                title="Games owned by the selected users, and not owned by unselected users (game list only)">
                                 <input type="checkbox" id="exclusive" name="exclusive">
                                 <label for="exclusive">Exclusively owned</label>
                             </div>
@@ -80,6 +81,10 @@
                             {% endfor -%}
                         </table>
                         <br>
+                        <div title="Only show games installed by all selected users (game list only)">
+                            <input type="checkbox" id="installed_only" name="installed_only">
+                            <label for="installed_only">Installed only</label><br>
+                        </div>
                         <input type="checkbox" id="include_single_player" name="include_single_player">
                         <label for="include_single_player">Include single-player</label><br>
                         <input type="checkbox" id="show_keys" name="show_keys">

--- a/version.py
+++ b/version.py
@@ -1,1 +1,1 @@
-VERSION = "1.3.0"
+VERSION = "1.3.1"


### PR DESCRIPTION
This adds the `-I/--installed-only` option (and a check box to the web UI) to only show games that are installed by all selected users. The short arg for `--include-single-player` has been changed to `-S`.

This also fixes game grid to not show single player games by default (https://github.com/eniklas/gamatrix-gog/issues/58).

Also, the caption no longer incorrectly reports that games have been excluded when they haven't in game grid (https://github.com/eniklas/gamatrix-gog/issues/57)