### PR TITLE
Ignore call to time.tzset() for Windows

### DIFF
--- a/gamatrix-gog.py
+++ b/gamatrix-gog.py
@@ -458,7 +458,9 @@ if __name__ == "__main__":
 
     if "mode" in config and config["mode"] == "server":
         # Start Flask to run in server mode until killed
-        time.tzset()
+        if os.name != "nt":
+            time.tzset()
+
         app.config["UPLOAD_FOLDER"] = config["db_path"]
         app.config["MAX_CONTENT_LENGTH"] = constants.UPLOAD_MAX_SIZE
         app.run(host=config["interface"], port=config["port"])

--- a/gamatrix-gog.py
+++ b/gamatrix-gog.py
@@ -459,7 +459,7 @@ if __name__ == "__main__":
     if "mode" in config and config["mode"] == "server":
         # Start Flask to run in server mode until killed
         if os.name != "nt":
-            time.tzset()
+            time.tzset()  # type: ignore
 
         app.config["UPLOAD_FOLDER"] = config["db_path"]
         app.config["MAX_CONTENT_LENGTH"] = constants.UPLOAD_MAX_SIZE


### PR DESCRIPTION
Fixes #93 