### PR TITLE
fix igdb release key retrieval

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,4 +138,4 @@ config-local.yaml
 .cache.json
 
 # Static files for flask, include logo images but not profile pics
-static/profile_img/*
+profile_img/

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ gamatrix respects the IGDB rate limit and auto-renews your access token, so once
 A [Dockerfile](Dockerfile) is provided for running gamatrix in a container. (See [contributing section below for details](#contributing)). Build it by:
 
 ```bash
-docker build -t gamatrix .
+docker build -t gamatrix:$(awk -F\" '{print $2}' src/gamatrix/version.py) -t gamatrix:latest .
 ```
 
 Then run it:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gamatrix"
-version = "1.4.3"
+version = "1.4.4"
 authors = [
     {name = "Erik Niklas", email = "github@bobanddoug.com"},
     {name = "Derek Keeler", email = "34773432+derek-keeler@users.noreply.github.com"},

--- a/src/gamatrix/helpers/gogdb_helper.py
+++ b/src/gamatrix/helpers/gogdb_helper.py
@@ -134,7 +134,9 @@ class gogDB:
         self.log.debug("Running query: {}".format(query))
         self.cursor.execute(query)
 
-        result = json.loads(self.cursor.fetchall()[0][-1])
+        raw_result = self.cursor.fetchall()
+        self.log.debug(f"raw_result = {raw_result}")
+        result = json.loads(raw_result[0][3])
         self.log.debug(f"{release_key}: all release keys: {result}")
         if "releases" not in result:
             self.log.debug(

--- a/src/gamatrix/version.py
+++ b/src/gamatrix/version.py
@@ -1,1 +1,1 @@
-VERSION = "1.4.3"
+VERSION = "1.4.4"


### PR DESCRIPTION
A few weeks ago, new GOG DBs started crashing the server when it processed them:

```
Feb 11 12:49:41 ebcc765a97b0[1812]: 2023-02-11 12:49:41 ERROR __main__ Exception on /compare [GET]
Feb 11 12:49:41 ebcc765a97b0[1812]: Traceback (most recent call last):
Feb 11 12:49:41 ebcc765a97b0[1812]:   File "/usr/local/lib/python3.11/site-packages/flask/app.py", line 2525, in wsgi_app
Feb 11 12:49:41 ebcc765a97b0[1812]:     response = self.full_dispatch_request()
Feb 11 12:49:41 ebcc765a97b0[1812]:                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Feb 11 12:49:41 ebcc765a97b0[1812]:   File "/usr/local/lib/python3.11/site-packages/flask/app.py", line 1822, in full_dispatch_request
Feb 11 12:49:41 ebcc765a97b0[1812]:     rv = self.handle_user_exception(e)
Feb 11 12:49:41 ebcc765a97b0[1812]:          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Feb 11 12:49:41 ebcc765a97b0[1812]:   File "/usr/local/lib/python3.11/site-packages/flask/app.py", line 1820, in full_dispatch_request
Feb 11 12:49:41 ebcc765a97b0[1812]:     rv = self.dispatch_request()
Feb 11 12:49:41 ebcc765a97b0[1812]:          ^^^^^^^^^^^^^^^^^^^^^^^
Feb 11 12:49:41 ebcc765a97b0[1812]:   File "/usr/local/lib/python3.11/site-packages/flask/app.py", line 1796, in dispatch_request
Feb 11 12:49:41 ebcc765a97b0[1812]:     return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)
Feb 11 12:49:41 ebcc765a97b0[1812]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Feb 11 12:49:41 ebcc765a97b0[1812]:   File "/usr/local/lib/python3.11/site-packages/gamatrix/__main__.py", line 164, in compare_libraries
Feb 11 12:49:41 ebcc765a97b0[1812]:     common_games = gog.get_common_games()
Feb 11 12:49:41 ebcc765a97b0[1812]:                    ^^^^^^^^^^^^^^^^^^^^^^
Feb 11 12:49:41 ebcc765a97b0[1812]:   File "/usr/local/lib/python3.11/site-packages/gamatrix/helpers/gogdb_helper.py", line 239, in get_common_games
Feb 11 12:49:41 ebcc765a97b0[1812]:     ] = self.get_igdb_release_key(
Feb 11 12:49:41 ebcc765a97b0[1812]:         ^^^^^^^^^^^^^^^^^^^^^^^^^^
Feb 11 12:49:41 ebcc765a97b0[1812]:   File "/usr/local/lib/python3.11/site-packages/gamatrix/helpers/gogdb_helper.py", line 137, in get_igdb_release_key
Feb 11 12:49:41 ebcc765a97b0[1812]:     result = json.loads(self.cursor.fetchall()[0][-1])
Feb 11 12:49:41 ebcc765a97b0[1812]:              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Feb 11 12:49:41 ebcc765a97b0[1812]:   File "/usr/local/lib/python3.11/json/__init__.py", line 339, in loads
Feb 11 12:49:41 ebcc765a97b0[1812]:     raise TypeError(f'the JSON object must be str, bytes or bytearray, '
Feb 11 12:49:41 ebcc765a97b0[1812]: TypeError: the JSON object must be str, bytes or bytearray, not NoneType
```

The schema in question is:

```sql
CREATE TABLE IF NOT EXISTS "GamePieces"(
	'releaseKey' TEXT NOT NULL,
	'gamePieceTypeId' INTEGER NOT NULL,
	'userId' INT64,
	'value' TEXT NOT NULL,
	'languageId' INTEGER NULL,
	CONSTRAINT 'FK_GamePieces_releaseKey_ReleaseKeys_key'
		FOREIGN KEY ('releaseKey')
		REFERENCES 'ReleaseKeys' ('key') ON DELETE CASCADE ON UPDATE CASCADE,
	CONSTRAINT 'FK_GamePieces_gamePieceTypeId_GamePieceTypes_id'
		FOREIGN KEY ('gamePieceTypeId')
		REFERENCES 'GamePieceTypes' ('id') ON DELETE CASCADE ON UPDATE CASCADE,
	CONSTRAINT 'FK_GamePieces_userId_Users_id'
		FOREIGN KEY ('userId')
		REFERENCES 'Users' ('id') ON DELETE CASCADE ON UPDATE CASCADE,
	CONSTRAINT 'FK_GamePieces_languageId_Languages_id'
		FOREIGN KEY ('languageId')
		REFERENCES 'Languages' ('id') ON DELETE CASCADE ON UPDATE CASCADE,
	CONSTRAINT 'UK_GamePieces_releaseKey_gamePieceTypeId_userId_languageId'
		UNIQUE ('releaseKey', 'gamePieceTypeId', 'userId', 'languageId'),
	CONSTRAINT 'CK_GamePieces_value'
		CHECK(trim([value]) <> ''),
	CONSTRAINT `CK_GamePieces_userId`
		CHECK([userId] > 0 OR [userId] IS NULL)
);
```

I haven't found release notes about this, but it seems that `languageId` was recently added. Gamatrix was assuming that the JSON blob it wanted (`value`) was the last item in the tuple. This updates it to assume it's the fourth item, which fixes the issue.