### PR TITLE
Increase max DB size; update deps

### DIFF
--- a/config-sample-windows.yaml
+++ b/config-sample-windows.yaml
@@ -21,8 +21,8 @@ allowed_cidrs:
 
 # IGDB client setup
 # Instructions for how to obtain a client ID & secret can be found at https://api-docs.igdb.com/#about
-igdb_client_secret: abcdefghi01234jklmno56789pqrst
 igdb_client_id: 0123uvwxyz4567abcde89012fg34hi
+igdb_client_secret: abcdefghi01234jklmno56789pqrst
 
 # Path to a file to cache the IGDB setup from
 cache: C:\Users\my_user\Documents\gog-cache.json

--- a/config-sample.yaml
+++ b/config-sample.yaml
@@ -18,8 +18,8 @@ allowed_cidrs:
 
 # IGDB client setup
 # Instructions for how to obtain a client ID & secret can be found at https://api-docs.igdb.com/#about
-igdb_client_secret: abcdefghi01234jklmno56789pqrst
 igdb_client_id: 0123uvwxyz4567abcde89012fg34hi
+igdb_client_secret: abcdefghi01234jklmno56789pqrst
 # File to cache the IGDB setup from
 cache: /path/to/cache/file
 

--- a/justfile
+++ b/justfile
@@ -38,6 +38,7 @@ build:
 
 # Run the container
 run:
+  #!/usr/bin/env bash
   PORT=${PROD_PORT:=80}
   TZ=${TZ:="America/Vancouver"}
   [ -z "$PROD_GOG_DBS" ] && echo "PROD_GOG_DBS env var must be set" && exit 1
@@ -53,8 +54,10 @@ run:
     -e TZ="$TZ" \
     -v ${PROD_GOG_DBS}:/usr/src/app/gog_dbs \
     --mount type=bind,source=${PROD_CACHE},target=/usr/src/app/.cache.json \
-    --mount type=bind,source=${PROD_CONFIG},target=/usr/src/app/config/config.yaml,readonly \
-    gamatrix
+    --mount type=bind,source=${PROD_CONFIG},target=/usr/src/app/config.yaml,readonly \
+    -w /usr/src/app \
+    gamatrix \
+    sh -c "python -m gamatrix -c config.yaml -p 80 -s"
 
 # Tag commit with current release version
 git-tag:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,9 +30,9 @@ classifiers = [
 dependencies = [
     "docopt==0.6.2",
     "Flask==3.1.0",
-    "Jinja2==3.1.2",
-    "pyyaml==6.0",
-    "requests==2.28.2",
+    "Jinja2==3.1.5",
+    "pyyaml==6.0.2",
+    "requests==2.32.3",
 ]
 
 # Optional dependencies for specific workflows. Install these with

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "gamatrix"
 # Changing this requires rebuilding even if in editable mode
-version = "1.4.6"
+version = "1.4.7"
 authors = [
     {name = "Erik Niklas", email = "github@bobanddoug.com"},
     {name = "Derek Keeler", email = "34773432+derek-keeler@users.noreply.github.com"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 ]
 dependencies = [
     "docopt==0.6.2",
-    "Flask==2.2.2",
+    "Flask==3.1.0",
     "Jinja2==3.1.2",
     "pyyaml==6.0",
     "requests==2.28.2",

--- a/src/gamatrix/helpers/constants.py
+++ b/src/gamatrix/helpers/constants.py
@@ -1,6 +1,6 @@
 # Allowed extensions for uploaded files
 UPLOAD_ALLOWED_EXTENSIONS = ["db"]
-UPLOAD_MAX_SIZE = 100 * 1024 * 1024
+UPLOAD_MAX_SIZE = 300 * 1024 * 1024
 
 # Full mapping is at https://api-docs.igdb.com/#external-game-enums,
 # but only Steam and GOG actually work; the other platforms' IDs

--- a/src/gamatrix/helpers/gogdb_helper.py
+++ b/src/gamatrix/helpers/gogdb_helper.py
@@ -236,10 +236,10 @@ class gogDB:
                         if platform == "steam":
                             game_list[release_key]["igdb_key"] = release_key
                         else:
-                            game_list[release_key][
-                                "igdb_key"
-                            ] = self.get_igdb_release_key(
-                                self.gamepiecetype_id, release_key
+                            game_list[release_key]["igdb_key"] = (
+                                self.get_igdb_release_key(
+                                    self.gamepiecetype_id, release_key
+                                )
                             )
 
                         self.log.debug(


### PR DESCRIPTION
- increase the max DB size that can be uploaded from 100MB to 300MB
- update the `just run` recipe which I don't think was working correctly before
- swaps `igdb_client_secret` and `igdb_client_id` in the sample configs to avoid confusion per https://github.com/eniklas/gamatrix/issues/126
- bump dependency versions