### PR TITLE
Support multiple DNS names

### DIFF
--- a/infrastructure/cdk/README.md
+++ b/infrastructure/cdk/README.md
@@ -52,6 +52,15 @@ a private config file, by default `../gamatrix-configs/cdk-config.yaml`
 hosted_zone: example.com          # existing Route 53 hosted zone
 site_domain: gamatrix.example.com # public hostname for the app
 email_from: noreply@example.com   # SES sender for password-reset email
+
+# Optional: extra hostnames that should also resolve to the same app.
+# alias_hosted_zone must be a Route 53-managed zone; alias_domains must be
+# subdomains of it. The ACM cert is extended with SANs for all alias_domains,
+# so there are no cert warnings. Primary and alias zones may differ.
+alias_hosted_zone: other.com
+alias_domains:
+  - games.other.com
+  - app.other.com
 ```
 
 If the file is absent (or omits `hosted_zone`/`site_domain`), the stack deploys

--- a/infrastructure/cdk/config.py
+++ b/infrastructure/cdk/config.py
@@ -45,10 +45,22 @@ def load_deploy_config() -> DeployConfig:
     import yaml
 
     data = yaml.safe_load(path.read_text()) or {}
+
+    alias_domains = data.get("alias_domains") or []
+    # YAML happily parses `alias_domains: games.other.com` as a scalar string.
+    # Without this guard it would later be iterated character-by-character,
+    # silently wiring up bogus single-letter "domains". Require a real list.
+    if not isinstance(alias_domains, list):
+        kind = type(alias_domains).__name__
+        raise ValueError(f"alias_domains must be a list of hostnames, got {kind}")
+    alias_hosted_zone = data.get("alias_hosted_zone")
+    if alias_domains and not alias_hosted_zone:
+        raise ValueError("alias_hosted_zone is required when alias_domains is set")
+
     return DeployConfig(
         hosted_zone=data.get("hosted_zone"),
         site_domain=data.get("site_domain"),
         email_from=data.get("email_from"),
-        alias_hosted_zone=data.get("alias_hosted_zone"),
-        alias_domains=data.get("alias_domains") or [],
+        alias_hosted_zone=alias_hosted_zone,
+        alias_domains=alias_domains,
     )

--- a/infrastructure/cdk/config.py
+++ b/infrastructure/cdk/config.py
@@ -13,7 +13,7 @@ Gateway URL -- so anyone can clone and deploy this repo without owning a domain.
 from __future__ import annotations
 
 import os
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
@@ -25,6 +25,11 @@ class DeployConfig:
     hosted_zone: str | None = None
     site_domain: str | None = None
     email_from: str | None = None
+    # Extra hostnames to alias to the same API Gateway endpoint. Each must be a
+    # subdomain of alias_hosted_zone (a Route53-managed zone). The primary cert
+    # is extended with SANs for all alias_domains so there are no cert warnings.
+    alias_hosted_zone: str | None = None
+    alias_domains: list[str] = field(default_factory=list)
 
     @property
     def has_custom_domain(self) -> bool:
@@ -44,4 +49,6 @@ def load_deploy_config() -> DeployConfig:
         hosted_zone=data.get("hosted_zone"),
         site_domain=data.get("site_domain"),
         email_from=data.get("email_from"),
+        alias_hosted_zone=data.get("alias_hosted_zone"),
+        alias_domains=data.get("alias_domains") or [],
     )

--- a/infrastructure/cdk/gamatrix_stack.py
+++ b/infrastructure/cdk/gamatrix_stack.py
@@ -86,12 +86,19 @@ class GamatrixStack(Stack):
         # a hosted zone + site domain. Otherwise the stack still deploys and the
         # app is reached via the default API Gateway URL.
         hosted_zone = None
+        alias_hosted_zone = None
         if cfg.has_custom_domain:
-            # Existing Route 53 hosted zone. Used to DNS-validate the ACM cert
-            # and alias the custom domain.
             hosted_zone = route53.HostedZone.from_lookup(
                 self, "HostedZone", domain_name=cfg.hosted_zone
             )
+            if cfg.alias_domains and cfg.alias_hosted_zone:
+                # Reuse the primary zone lookup if they happen to be the same.
+                if cfg.alias_hosted_zone == cfg.hosted_zone:
+                    alias_hosted_zone = hosted_zone
+                else:
+                    alias_hosted_zone = route53.HostedZone.from_lookup(
+                        self, "AliasHostedZone", domain_name=cfg.alias_hosted_zone
+                    )
 
         common_env = {
             "TABLE_PREFIX": TABLE_PREFIX,
@@ -147,7 +154,7 @@ class GamatrixStack(Stack):
             s3.NotificationKeyFilter(prefix="uploads/"),
         )
 
-        http_api = self._http_api(web_fn, cfg, hosted_zone)
+        http_api = self._http_api(web_fn, cfg, hosted_zone, alias_hosted_zone)
 
         # The app builds password-reset links from APP_BASE_URL. Use the custom
         # domain when configured, else the default API Gateway URL.
@@ -168,18 +175,30 @@ class GamatrixStack(Stack):
         web_fn: lambda_.IFunction,
         cfg: DeployConfig,
         hosted_zone: route53.IHostedZone | None,
+        alias_hosted_zone: route53.IHostedZone | None = None,
     ) -> apigw.HttpApi:
         integration = integrations.HttpLambdaIntegration("WebIntegration", web_fn)
 
         if not (cfg.has_custom_domain and hosted_zone is not None):
             return apigw.HttpApi(self, "HttpApi", default_integration=integration)
 
-        # TLS cert for the custom domain, DNS-validated through Route 53.
+        # Build a validation map so primary and alias domains can live in
+        # different Route 53 hosted zones.
+        validation_map: dict[str, route53.IHostedZone] = {
+            cfg.site_domain: hosted_zone  # type: ignore[index]
+        }
+        aliases_to_wire: list[str] = []
+        if alias_hosted_zone and cfg.alias_domains:
+            for alias in cfg.alias_domains:
+                validation_map[alias] = alias_hosted_zone
+                aliases_to_wire.append(alias)
+
         certificate = acm.Certificate(
             self,
             "SiteCertificate",
             domain_name=cfg.site_domain,
-            validation=acm.CertificateValidation.from_dns(hosted_zone),
+            subject_alternative_names=aliases_to_wire or None,
+            validation=acm.CertificateValidation.from_dns_multi_zone(validation_map),
         )
         domain_name = apigw.DomainName(
             self,
@@ -193,7 +212,6 @@ class GamatrixStack(Stack):
             default_integration=integration,
             default_domain_mapping=apigw.DomainMappingOptions(domain_name=domain_name),
         )
-        # Alias record so the hostname resolves to the API Gateway domain.
         route53.ARecord(
             self,
             "SiteAliasRecord",
@@ -206,6 +224,34 @@ class GamatrixStack(Stack):
                 )
             ),
         )
+
+        # Wire each alias: its own API Gateway domain name + mapping + A record.
+        for i, alias in enumerate(aliases_to_wire):
+            alias_dn = apigw.DomainName(
+                self,
+                f"AliasDomain{i}",
+                domain_name=alias,
+                certificate=certificate,
+            )
+            apigw.ApiMapping(
+                self,
+                f"AliasMapping{i}",
+                api=http_api,
+                domain_name=alias_dn,
+            )
+            route53.ARecord(
+                self,
+                f"AliasARecord{i}",
+                zone=alias_hosted_zone,  # type: ignore[arg-type]
+                record_name=alias,
+                target=route53.RecordTarget.from_alias(
+                    route53_targets.ApiGatewayv2DomainProperties(
+                        alias_dn.regional_domain_name,
+                        alias_dn.regional_hosted_zone_id,
+                    )
+                ),
+            )
+
         return http_api
 
     def _create_tables(self) -> dict[str, dynamodb.Table]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gamatrix"
-version = "2.0.0"
+version = "2.0.1"
 authors = [
     {name = "Erik Niklas", email = "github@bobanddoug.com"},
     {name = "Derek Keeler", email = "34773432+derek-keeler@users.noreply.github.com"},

--- a/tests/test_cdk_config.py
+++ b/tests/test_cdk_config.py
@@ -1,0 +1,76 @@
+"""Regression tests for CDK deploy-config alias validation.
+
+These tests load the infrastructure deployment config from a temporary
+``cdk-config.yaml`` file and assert that invalid alias-domain settings are
+rejected before stack synthesis. The expected result is a fast failure for bad
+input, rather than silently skipping alias wiring or treating a scalar string as
+an iterable of one-character domains.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+CDK_CONFIG_PATH = PROJECT_ROOT / "infrastructure" / "cdk" / "config.py"
+
+
+def _load_cdk_config_module() -> ModuleType:
+    """Load the CDK config module directly from the infrastructure tree."""
+    spec = importlib.util.spec_from_file_location(
+        "gamatrix_cdk_config_test", CDK_CONFIG_PATH
+    )
+    assert spec is not None
+    assert spec.loader is not None
+
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_load_deploy_config_rejects_alias_domains_scalar(tmp_path, monkeypatch):
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    (config_dir / "cdk-config.yaml").write_text(
+        "\n".join(
+            [
+                "hosted_zone: example.com",
+                "site_domain: games.example.com",
+                "alias_hosted_zone: other.com",
+                "alias_domains: games.other.com",
+            ]
+        )
+    )
+    monkeypatch.setenv("GAMATRIX_CONFIG_DIR", str(config_dir))
+
+    config = _load_cdk_config_module()
+
+    with pytest.raises(ValueError, match="alias_domains"):
+        config.load_deploy_config()
+
+
+def test_load_deploy_config_requires_alias_hosted_zone(tmp_path, monkeypatch):
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    (config_dir / "cdk-config.yaml").write_text(
+        "\n".join(
+            [
+                "hosted_zone: example.com",
+                "site_domain: games.example.com",
+                "alias_domains:",
+                "  - games.other.com",
+            ]
+        )
+    )
+    monkeypatch.setenv("GAMATRIX_CONFIG_DIR", str(config_dir))
+
+    config = _load_cdk_config_module()
+
+    with pytest.raises(ValueError, match="alias_hosted_zone"):
+        config.load_deploy_config()


### PR DESCRIPTION
This adds support for DNS aliases for the web app to prevent cert warnings. Only aliases in the same domain are supported for now.