### PR TITLE
Fix igdb retries

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gamatrix"
-version = "2.0.0"
+version = "2.0.1"
 authors = [
     {name = "Erik Niklas", email = "github@bobanddoug.com"},
     {name = "Derek Keeler", email = "34773432+derek-keeler@users.noreply.github.com"},

--- a/src/gamatrix/igdb/enricher.py
+++ b/src/gamatrix/igdb/enricher.py
@@ -12,6 +12,7 @@ from gamatrix.config import Settings, get_settings, resolve_igdb_credentials
 from gamatrix.constants import (
     ENRICHMENT_DONE,
     ENRICHMENT_NOT_FOUND,
+    ENRICHMENT_PENDING,
     JOB_COMPLETED,
     JOB_FAILED,
     JOB_RUNNING,
@@ -42,6 +43,8 @@ async def run_job(
     for rk in release_keys:
         game = games.get(rk)
         if game is None:
+            continue
+        if game.get("enrichment_status") not in (None, ENRICHMENT_PENDING):
             continue
         by_igdb_key.setdefault(game["igdb_key"], []).append(rk)
 


### PR DESCRIPTION
This fixes an issue where enrichment gets stuck and spams IGDB:

1. The attempt counter resets on every _query call (client.py:119)

for attempt in range(6): is scoped to a single _query invocation. resolve_igdb_id calls _query up to four times (external UID, slug, fuzzy search, stripped title), and fetch_metadata adds two more (game info, multiplayer modes). Each of those calls starts a fresh attempt=0. The _RateLimiter._last carries over between calls (so the actual wait is correct), but the logged attempt number and the backoff amount both reset. That's why you see "attempt 0" over and over â it's not the same retry loop, it's a new _query invocation that hits 429 at its own attempt 0.

2. The enricher re-processes already-enriched games on every Lambda re-invocation (enricher.py:40-46)

batch_get_games fetches all release keys from the job with their current DynamoDB state, but there's no filter to skip games whose enrichment_status is already done or not_found. When the Lambda times out mid-job and SQS requeues the message, the new invocation starts from the top and fires fresh IGDB API calls for every game â including the ones already finished. After burning through the rate limit on the already-enriched games, IGDB starts returning 429 again before reaching the 10 still-pending games. Lambda times out, SQS requeues, repeat.