### PR TITLE
Auto bump version on merge

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @derek-keeler @eniklas

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,37 @@
+<!--
+  Thanks for contributing! Fill in the sections below, then check the
+  versioning note before you merge.
+-->
+
+## What
+
+<!-- A short description of the change and why it's needed. -->
+
+## How
+
+<!-- Notable implementation details, trade-offs, or follow-ups. -->
+
+## Checklist
+
+- [ ] `just check` passes (lint + typecheck + tests)
+- [ ] Tests added/updated for the change
+- [ ] Version label applied if this is more than a patch (see below)
+
+## Versioning
+
+**You don't need to bump the version manually.** When this PR merges to `master`,
+a GitHub Action (`.github/workflows/version.yml`) reads the latest semver tag,
+computes the next one, and tags the merge commit. The package version is derived
+from that tag by setuptools_scm — nothing is hardcoded in `pyproject.toml`.
+
+The bump level is controlled by labels on this PR:
+
+| Label on PR          | Result            | Example         |
+| -------------------- | ----------------- | --------------- |
+| _(none)_             | patch bump        | `2.0.1 → 2.0.2` |
+| `new minor version`  | minor bump        | `2.0.1 → 2.1.0` |
+| `new major version`  | major bump        | `2.0.1 → 3.0.0` |
+
+Apply at most one of the version labels. If both are present, `new major version`
+wins. Squash- or merge-commit either works — the action tags whatever commit lands
+on `master`.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,14 +13,14 @@
 
 ## Checklist
 
-- [ ] `just check` passes (lint + typecheck + tests)
+- [ ] PR checks pass
 - [ ] Tests added/updated for the change
 - [ ] Version label applied if this is more than a patch (see below)
 
 ## Versioning
 
 **You don't need to bump the version manually.** When this PR merges to `master`,
-a GitHub Action (`.github/workflows/version.yml`) reads the latest semver tag,
+a [GitHub Action](.github/workflows/version.yml) reads the latest semver tag,
 computes the next one, and tags the merge commit. The package version is derived
 from that tag by setuptools_scm — nothing is hardcoded in `pyproject.toml`.
 
@@ -33,5 +33,4 @@ The bump level is controlled by labels on this PR:
 | `new major version`  | major bump        | `2.0.1 → 3.0.0` |
 
 Apply at most one of the version labels. If both are present, `new major version`
-wins. Squash- or merge-commit either works — the action tags whatever commit lands
-on `master`.
+wins.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,10 @@ jobs:
       PYTHONDEVMODE: 1
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
+      with:
+        # Full history + tags so setuptools_scm can derive the version.
+        fetch-depth: 0
 
     - name: Set up Python
       uses: actions/setup-python@v3

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -72,4 +72,10 @@ jobs:
           git tag -a "$next" -m "Release $next" "$SHA"
           git push origin "$next"
 
-          echo "### Tagged \`$next\` (\`$level\` bump from \`$latest\`)" >> "$GITHUB_STEP_SUMMARY"
+          # --- Publish a GitHub release for the tag -------------------------
+          gh release create "$next" \
+            --title "$next" \
+            --target "$SHA" \
+            --generate-notes
+
+          echo "### Released \`$next\` (\`$level\` bump from \`$latest\`)" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -1,0 +1,75 @@
+name: Version
+
+# On every merge to master, compute the next semantic version from the latest
+# tag and create a new tag on the merge commit. The bump level is patch by
+# default, or minor/major if the merged PR carried the matching label:
+#   - "new minor version" -> bump the minor component
+#   - "new major version" -> bump the major component
+
+on:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: write       # create and push tags
+  pull-requests: read   # read the merged PR's labels
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Need full history + all tags to find the latest version.
+          fetch-depth: 0
+
+      - name: Compute next version and tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          # --- Determine the bump level from the merged PR's labels ----------
+          labels="$(gh api "repos/$REPO/commits/$SHA/pulls" \
+            --jq '.[].labels[].name' 2>/dev/null || true)"
+          echo "PR labels for $SHA:"
+          echo "${labels:-<none>}"
+
+          level=patch
+          if grep -qx "new major version" <<< "$labels"; then
+            level=major
+          elif grep -qx "new minor version" <<< "$labels"; then
+            level=minor
+          fi
+          echo "Bump level: $level"
+
+          # --- Find the latest semver tag -----------------------------------
+          latest="$(git tag --list --sort=-v:refname \
+            | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | head -n1 || true)"
+          latest="${latest:-0.0.0}"
+          echo "Latest tag: $latest"
+
+          IFS=. read -r major minor patch <<< "$latest"
+          case "$level" in
+            major) major=$((major + 1)); minor=0; patch=0 ;;
+            minor) minor=$((minor + 1)); patch=0 ;;
+            patch) patch=$((patch + 1)) ;;
+          esac
+          next="$major.$minor.$patch"
+          echo "Next version: $next"
+
+          # --- Tag the merge commit (idempotent) ----------------------------
+          if git rev-parse -q --verify "refs/tags/$next" >/dev/null; then
+            echo "Tag $next already exists; nothing to do."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "$next" -m "Release $next" "$SHA"
+          git push origin "$next"
+
+          echo "### Tagged \`$next\` (\`$level\` bump from \`$latest\`)" >> "$GITHUB_STEP_SUMMARY"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,10 +44,6 @@ uv run pytest tests/test_gogdb.py
 # Auto-format
 just format           # black .
 
-# Bump version (patch by default; pass "minor" or "major" for others)
-just bump-version
-just bump-version minor
-
 # Build Lambda container images
 just build
 
@@ -109,4 +105,12 @@ DynamoDB tables (all `PAY_PER_REQUEST`, PITR on, name-prefixed with `TABLE_PREFI
 
 ## Version
 
-Version is defined in `pyproject.toml` under `[project]`. Use `just bump-version` to update it. Bump before merging a PR.
+Versioning is automatic — there's nothing to bump by hand. setuptools_scm derives the package version from the latest git tag (`[tool.setuptools_scm]` in `pyproject.toml`; `__version__` in `src/gamatrix/__init__.py` reads it from the installed metadata).
+
+On every merge to `master`, `.github/workflows/version.yml` computes the next semver from the latest tag and tags the merge commit. The bump is **patch** by default; add a label to the PR to change it:
+- `new minor version` → bumps the minor component
+- `new major version` → bumps the major component
+
+(These two labels must exist in the repo for the workflow to pick them up.)
+
+Because the Docker/CDK build context excludes `.git`, image builds receive the version via the `SETUPTOOLS_SCM_PRETEND_VERSION` build arg — `just build` passes it from `git describe`, and the CDK stack (`_project_version()`) passes it at synth time.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,17 @@
 # syntax=docker/dockerfile:1
 
+# Version is normally derived from the git tag by setuptools_scm, but the build
+# context here has no git history, so callers pass it in instead. Defaults to
+# 0.0.0 so ad-hoc builds still succeed.
+ARG SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0
+
 # ---- base: shared layer with uv and the project source ----
 FROM python:3.12-slim AS base
+ARG SETUPTOOLS_SCM_PRETEND_VERSION
 ENV PYTHONUNBUFFERED=1 \
     PIP_NO_CACHE_DIR=1 \
-    UV_SYSTEM_PYTHON=1
+    UV_SYSTEM_PYTHON=1 \
+    SETUPTOOLS_SCM_PRETEND_VERSION=${SETUPTOOLS_SCM_PRETEND_VERSION}
 WORKDIR /app
 # Install uv (https://docs.astral.sh/uv/)
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
@@ -19,6 +26,8 @@ CMD ["uvicorn", "gamatrix.app:app", "--host", "0.0.0.0", "--port", "8080", "--re
 
 # ---- lambda-web: image for the API Gateway-backed web Lambda ----
 FROM public.ecr.aws/lambda/python:3.12 AS lambda-web
+ARG SETUPTOOLS_SCM_PRETEND_VERSION
+ENV SETUPTOOLS_SCM_PRETEND_VERSION=${SETUPTOOLS_SCM_PRETEND_VERSION}
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 COPY pyproject.toml README.md ./
 COPY src ./src

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Then seed user accounts by running `scripts/seed_users.py` against the deployed 
 
 ## Contributing
 
-PRs are welcome. If you're making non-trivial changes, please include test output. Before opening a PR, run `just check` and bump the version in `pyproject.toml` with `just bump-version` (bumps patch by default; pass `minor` or `major` for those).
+PRs are welcome. If you're making non-trivial changes, please include test output. Before opening a PR, run `just check`. Versioning is automatic: merging to `master` tags the commit with the next patch version. For a bigger bump, add the `new minor version` or `new major version` label to your PR.
 
 ### Development setup
 

--- a/infrastructure/cdk/gamatrix_stack.py
+++ b/infrastructure/cdk/gamatrix_stack.py
@@ -16,6 +16,7 @@ exposing the default API Gateway URL and skipping SES.
 
 from __future__ import annotations
 
+import subprocess
 from pathlib import Path
 
 from aws_cdk import (
@@ -44,6 +45,30 @@ from config import DeployConfig
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 TABLE_PREFIX = "gamatrix"
 DEFAULT_EMAIL_FROM = "noreply@example.com"
+
+
+def _project_version() -> str:
+    """Latest semver git tag, passed into the image build as the package version.
+
+    The Docker build context excludes .git, so setuptools_scm can't derive the
+    version itself; we resolve it here at synth time and forward it as a build
+    arg (SETUPTOOLS_SCM_PRETEND_VERSION).
+    """
+    try:
+        return subprocess.check_output(
+            [
+                "git",
+                "describe",
+                "--tags",
+                "--abbrev=0",
+                "--match",
+                "[0-9]*.[0-9]*.[0-9]*",
+            ],
+            cwd=PROJECT_ROOT,
+            text=True,
+        ).strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return "0.0.0"
 
 
 class GamatrixStack(Stack):
@@ -298,6 +323,9 @@ class GamatrixStack(Stack):
                 file="Dockerfile",
                 target=image_target,
                 cmd=[cmd],
+                build_args={
+                    "SETUPTOOLS_SCM_PRETEND_VERSION": _project_version(),
+                },
                 exclude=[
                     ".git",
                     ".venv",

--- a/justfile
+++ b/justfile
@@ -1,36 +1,13 @@
 set dotenv-load
 
-version := `grep "^version =" pyproject.toml |awk -F\" '{print $2}'`
+# Latest release version, taken from the most recent semver git tag. Tags are
+# created automatically on merge to master (see .github/workflows/version.yml).
+version := `git describe --tags --abbrev=0 --match "[0-9]*.[0-9]*.[0-9]*" 2>/dev/null || echo 0.0.0`
 container_name := "gamatrix"
 
 # List recipes
 default:
   just --list
-
-# Increment version; pass in "major" or "minor" to bump those
-bump-version type="patch":
-  #!/usr/bin/env bash
-  set -euo pipefail
-  old_version={{version}}
-  IFS=. components=(${old_version##*-})
-  major=${components[0]}
-  minor=${components[1]}
-  patch=${components[2]}
-  type={{type}}
-  case $type in
-    major|MAJOR)
-      new_version="$((major+1)).0.0";;
-    minor|MINOR)
-      new_version="$major.$((minor+1)).0";;
-    patch|PATCH)
-      new_version="$major.$minor.$((patch+1))";;
-    *)
-      echo "Bad type: $type"
-      echo "Valid types are major, minor, patch"
-      exit 1;;
-  esac
-  echo "Bumping version from $old_version to $new_version"
-  sed -i "s/^version =.*/version = \"$new_version\"/" pyproject.toml
 
 # Install dependencies into a local uv-managed virtualenv
 install:
@@ -75,9 +52,9 @@ format:
 
 # Build the Lambda container images
 build:
-  docker build --target lambda-web -t {{container_name}}-web:{{version}} .
-  docker build --target lambda-enricher -t {{container_name}}-enricher:{{version}} .
-  docker build --target lambda-parser -t {{container_name}}-parser:{{version}} .
+  docker build --build-arg SETUPTOOLS_SCM_PRETEND_VERSION={{version}} --target lambda-web -t {{container_name}}-web:{{version}} .
+  docker build --build-arg SETUPTOOLS_SCM_PRETEND_VERSION={{version}} --target lambda-enricher -t {{container_name}}-enricher:{{version}} .
+  docker build --build-arg SETUPTOOLS_SCM_PRETEND_VERSION={{version}} --target lambda-parser -t {{container_name}}-parser:{{version}} .
 
 # Deploy infrastructure with CDK
 deploy:
@@ -89,13 +66,3 @@ set-igdb-secret client_id client_secret:
     --region ca-central-1 \
     --secret-id gamatrix/igdb \
     --secret-string "{\"client_id\":\"{{client_id}}\",\"client_secret\":\"{{client_secret}}\"}"
-
-# Tag commit with current release version
-git-tag:
-  #!/usr/bin/env bash
-  if [ ! "$(git diff --quiet --exit-code)" ]; then
-    git commit -am "bump version"
-    git tag --annotate --message="bump to version {{version}}" "{{version}}"
-    git push
-    git push --tags
-  fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gamatrix"
-version = "2.0.1"
+dynamic = ["version"]
 authors = [
     {name = "Erik Niklas", email = "github@bobanddoug.com"},
     {name = "Derek Keeler", email = "34773432+derek-keeler@users.noreply.github.com"},
@@ -63,8 +63,14 @@ cdk = [
 ]
 
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools>=64", "setuptools_scm>=8"]
 build-backend = "setuptools.build_meta"
+
+# Version is derived from the latest git tag (see .github/workflows/version.yml).
+# In the Docker/CDK builds the git history is unavailable, so the version is
+# injected via the SETUPTOOLS_SCM_PRETEND_VERSION build arg instead.
+[tool.setuptools_scm]
+fallback_version = "0.0.0"
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/src/gamatrix/__init__.py
+++ b/src/gamatrix/__init__.py
@@ -1,3 +1,9 @@
 """gamatrix: compare game libraries across users via GOG Galaxy databases."""
 
-__version__ = "2.0.0"
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    # Set at build time by setuptools_scm from the latest git tag.
+    __version__ = version("gamatrix")
+except PackageNotFoundError:  # running from a source tree that isn't installed
+    __version__ = "0.0.0+unknown"


### PR DESCRIPTION
This adds automatic versioning. Merge to `main` tags the new commit with the next SemVer (patch rev by default, major and minor bumps controlled by labels), and creates a new release. The version in the docker containers is handled dynamically at build time.