### PR TITLE
Restore "Show product keys" option

### DIFF
--- a/src/gamatrix/games/preferences.py
+++ b/src/gamatrix/games/preferences.py
@@ -11,6 +11,7 @@ DEFAULT_PREFERENCES: dict[str, Any] = {
     "default_view": "list",
     "selected_users": "all",
     "exclusive": False,
+    "show_keys": False,
 }
 
 

--- a/src/gamatrix/games/routes.py
+++ b/src/gamatrix/games/routes.py
@@ -61,6 +61,7 @@ def _parse_options(request: Request, user: dict) -> CompareOptions:
         exclusive=flag("exclusive", prefs["exclusive"]),
         all_games=view == "grid",
         randomize=flag("randomize", False),
+        show_keys=flag("show_keys", prefs["show_keys"]),
         sort=qp.get("sort", "title"),
         direction=qp.get("dir", "asc"),
     )

--- a/src/gamatrix/games/service.py
+++ b/src/gamatrix/games/service.py
@@ -24,6 +24,7 @@ class CompareOptions:
     exclusive: bool = False
     all_games: bool = False  # grid view: list everything owned, no intersection
     randomize: bool = False
+    show_keys: bool = False  # show each game's GOG release key as an extra column
     sort: str = "title"
     direction: str = "asc"
 

--- a/src/gamatrix/preferences.py
+++ b/src/gamatrix/preferences.py
@@ -51,6 +51,7 @@ async def save_preferences(
         "include_single_player": flag("single_player"),
         "installed_only": flag("installed_only"),
         "exclusive": flag("exclusive"),
+        "show_keys": flag("show_keys"),
         "exclude_platforms": form.getlist("exclude") or qp.getlist("exclude"),
         "default_view": form.get("view", qp.get("view", "list")),
         "selected_users": selected if selected else "all",

--- a/src/gamatrix/templates/games.html.jinja
+++ b/src/gamatrix/templates/games.html.jinja
@@ -50,6 +50,8 @@
             {% if opts.exclusive %}checked{% endif %}> Exclusively owned</label>
         <label><input type="checkbox" name="randomize" value="true"
             {% if opts.randomize %}checked{% endif %}> Pick a random game</label>
+        <label><input type="checkbox" name="show_keys" value="true"
+            {% if opts.show_keys %}checked{% endif %}> Show product keys</label>
     </fieldset>
 
     <fieldset class="filter-group">

--- a/src/gamatrix/templates/games_table.html.jinja
+++ b/src/gamatrix/templates/games_table.html.jinja
@@ -34,6 +34,7 @@
                 {{ sort_header('Installed', 'installed') }}
                 <th>Comment</th>
             {% endif %}
+            {% if opts.show_keys %}<th>Release Key</th>{% endif %}
         </tr>
     </thead>
     <tbody>
@@ -82,6 +83,7 @@
             </td>
             <td>{{ game.comment }}</td>
             {% endif %}
+            {% if opts.show_keys %}<td>{{ game.release_key }}</td>{% endif %}
         </tr>
     {% endfor %}
     </tbody>

--- a/src/gamatrix/templates/preferences.html.jinja
+++ b/src/gamatrix/templates/preferences.html.jinja
@@ -37,6 +37,8 @@
             {% if prefs.installed_only %}checked{% endif %}> Installed only</label>
         <label><input type="checkbox" name="exclusive" value="true"
             {% if prefs.exclusive %}checked{% endif %}> Exclusively owned</label>
+        <label><input type="checkbox" name="show_keys" value="true"
+            {% if prefs.show_keys %}checked{% endif %}> Show product keys</label>
     </fieldset>
 
     <fieldset class="filter-group">


### PR DESCRIPTION
The v1 UI had a **Show product keys** checkbox that added a Release Key column to the results table. It was dropped in the v2 rewrite — this brings it back.

## Changes
- `CompareOptions.show_keys`, parsed from the `show_keys` query flag (falling back to the saved preference) in `games/routes.py`
- `show_keys` added to `DEFAULT_PREFERENCES` and persisted by the preferences save route, so it can be saved as a default
- "Show product keys" checkbox on the filter bar (`games.html.jinja`) and the preferences page (`preferences.html.jinja`)
- Release Key column (`game.release_key`) in `games_table.html.jinja`, rendered only when enabled, in both list and grid views

## Notes
- In v2, cross-platform copies owned by the same people are merged into one row, so that row shows a single representative release key (matching v1's merge behavior).

## Testing
- `just check` is green (black, flake8, mypy, 32 tests)
- Render check confirms the column appears only when the option is enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)