### PR TITLE
Restore v1 grid ownership colors

### DIFF
--- a/src/gamatrix/static/style.css
+++ b/src/gamatrix/static/style.css
@@ -6,6 +6,8 @@
   --row-a: rgb(180, 227, 239);
   --row-b: rgb(201, 235, 243);
   --row-text: #102027;
+  --owned: rgb(182, 215, 168);
+  --unowned: rgb(234, 153, 153);
 }
 
 body {
@@ -81,6 +83,9 @@ table.results thead th:hover { filter: brightness(1.05); }
 table.results tbody tr:nth-child(odd) { background-color: var(--row-a); }
 table.results tbody tr:nth-child(even) { background-color: var(--row-b); }
 table.results tr.subthreshold td { color: grey; }
+/* Grid view: per-user ownership cells (green = owned, red = not owned), v1 scheme. */
+table.results td.owned { background-color: var(--owned); }
+table.results td.unowned { background-color: var(--unowned); }
 .platform-icons { float: right; white-space: nowrap; }
 .platform-icons img { vertical-align: middle; }
 .sort-arrow { font-size: 0.8em; }

--- a/src/gamatrix/templates/games_table.html.jinja
+++ b/src/gamatrix/templates/games_table.html.jinja
@@ -56,12 +56,12 @@
             {% if is_grid %}
                 {% for uid in selected %}
                 {% if uid in users %}
-                <td style="text-align:center;">
+                <td class="{{ 'owned' if uid in game.owners else 'unowned' }}" style="text-align:center;">
                     {% if uid in game.installed %}
                         {% if users[uid].pic %}
                         <img src="/static/profile_img/{{ users[uid].pic }}" width="18" height="18" title="installed">
                         {% else %}✓{% endif %}
-                    {% elif uid in game.owners %}●{% endif %}
+                    {% endif %}
                 </td>
                 {% endif %}
                 {% endfor %}


### PR DESCRIPTION
In v1, the game **grid** view colored each per-user cell to show ownership: green when the user owned the game, red when they didn't. The v2 rewrite replaced this with a single `●` marker and no color. This brings the v1 scheme back.

## Changes
- `style.css`: add `--owned` / `--unowned` CSS vars using v1's exact colors (`rgb(182,215,168)` green / `rgb(234,153,153)` red) and `td.owned` / `td.unowned` rules.
- `games_table.html.jinja`: apply `owned`/`unowned` classes to grid cells. Since the cell color now conveys ownership, the redundant `●` marker is removed; the installed indicator (profile pic or ✓) is unchanged.

## Notes
- Only affects the grid view; the list view is untouched.
- Cell text uses the existing `--row-text` dark color, which stays readable on both green and red.

## Testing
- Render check: with two selected users, an owned+installed cell gets `class="owned"` and shows ✓, a non-owner cell gets `class="unowned"`, and `●` is gone.
- `just check` green (lint, mypy, 32 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)