### PR TITLE
Show Comment column in game grid view

### DIFF
--- a/src/gamatrix/templates/games_table.html.jinja
+++ b/src/gamatrix/templates/games_table.html.jinja
@@ -32,8 +32,8 @@
             {{ sort_header('Rating', 'rating') }}
             {% if not is_grid %}
                 {{ sort_header('Installed', 'installed') }}
-                <th>Comment</th>
             {% endif %}
+            <th>Comment</th>
         </tr>
     </thead>
     <tbody>
@@ -80,8 +80,8 @@
                     {% endfor %}
                 {% endif %}
             </td>
-            <td>{{ game.comment }}</td>
             {% endif %}
+            <td>{{ game.comment }}</td>
         </tr>
     {% endfor %}
     </tbody>


### PR DESCRIPTION
v1's grid view had a **Comment** column. In the v2 rewrite, the Comment header and cell were nested inside the list-only (`{% if not is_grid %}`) block, so it only showed in the list view. This moves Comment out of that guard so it appears in both views.

## Changes
- `games_table.html.jinja`: move the `<th>Comment</th>` header and the `<td>{{ game.comment }}</td>` cell outside the `not is_grid` block. The **Installed** column stays list-only, since the grid already shows per-user install status inside each ownership cell.

## Testing
- Render check (both views): header/body column counts match (grid 6/6 with 2 users, list 5/5), and the Comment header + value appear in each.
- `just check` green (lint, mypy, 32 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)