### PR TITLE
Fix Include single-player toggle ignoring unchecked state

### DIFF
--- a/src/gamatrix/games/routes.py
+++ b/src/gamatrix/games/routes.py
@@ -47,10 +47,16 @@ def _parse_options(request: Request, user: dict) -> CompareOptions:
         else:
             selected = list(pref_users)
 
+    # When the filter form is submitted it includes a hidden `filters_active`
+    # marker. An unchecked checkbox sends no value, so without this marker we
+    # can't tell "user turned it off" from "not specified". When the form was
+    # submitted, an absent flag means off; on a bare page load, use the pref.
+    form_submitted = "filters_active" in qp
+
     def flag(name: str, default: bool) -> bool:
         if name in qp:
             return qp[name] in ("true", "on", "1")
-        return default
+        return False if form_submitted else default
 
     view = qp.get("view", prefs["default_view"])
     return CompareOptions(

--- a/src/gamatrix/templates/games.html.jinja
+++ b/src/gamatrix/templates/games.html.jinja
@@ -20,6 +20,10 @@
       hx-include="#filters"
       class="filters">
 
+    {# Marks requests as coming from the filter form so the server treats an
+       unchecked checkbox as "off" rather than falling back to a saved pref. #}
+    <input type="hidden" name="filters_active" value="1">
+
     <fieldset class="filter-group">
         <legend>Users</legend>
         {% for uid, u in users.items() %}

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,0 +1,56 @@
+"""Tests for request-option parsing in the games routes.
+
+Focus on how `_parse_options` resolves boolean filter checkboxes. An unchecked
+HTML checkbox submits no value, so the filter form sends a hidden
+`filters_active` marker; when present, an absent flag means "off" rather than
+falling back to the user's saved preference.
+"""
+
+from __future__ import annotations
+
+import types
+
+from starlette.datastructures import QueryParams
+
+from gamatrix.games import routes
+
+
+def _opts(query_string: str, preferences: dict):
+    request = types.SimpleNamespace(query_params=QueryParams(query_string))
+    return routes._parse_options(request, {"preferences": preferences})
+
+
+def test_unchecked_box_overrides_saved_on_preference():
+    """Submitting the form with the box unchecked turns the option off even when
+    the saved preference is on (the reported single-player bug)."""
+    prefs = {"include_single_player": True, "selected_users": ["1"]}
+    opts = _opts("user=1&filters_active=1", prefs)
+    assert opts.include_single_player is False
+
+
+def test_checked_box_turns_option_on():
+    prefs = {"include_single_player": False, "selected_users": ["1"]}
+    opts = _opts("user=1&filters_active=1&single_player=true", prefs)
+    assert opts.include_single_player is True
+
+
+def test_bare_page_load_uses_saved_preference():
+    """A bare /games load (no filter form submitted) still honors saved prefs."""
+    prefs = {"include_single_player": True, "selected_users": ["1"]}
+    opts = _opts("user=1", prefs)
+    assert opts.include_single_player is True
+
+
+def test_marker_applies_to_all_boolean_flags():
+    """All boolean filter checkboxes share the same resolution, so an absent one
+    on a submitted form is off regardless of saved prefs."""
+    prefs = {
+        "include_single_player": True,
+        "installed_only": True,
+        "exclusive": True,
+        "selected_users": ["1"],
+    }
+    opts = _opts("user=1&filters_active=1", prefs)
+    assert opts.include_single_player is False
+    assert opts.installed_only is False
+    assert opts.exclusive is False


### PR DESCRIPTION
## Problem
"Include single-player" had no effect — games with max players = 1 showed whether or not the box was checked.

## Root cause
An unchecked HTML checkbox submits **no value**. In `_parse_options`, the flag resolver fell back to the saved preference whenever a param was absent:

```python
def flag(name, default):
    if name in qp:
        return qp[name] in ("true", "on", "1")
    return default   # absent -> saved pref, even when the user unchecked it
```

So it couldn't distinguish "user turned it off" from "not specified." Once a user saved `include_single_player=True`, unchecking the box fell back to the saved `True` and never took effect. Reproduced:

```
box unchecked, saved pref True -> include_single_player = True   (bug)
box checked                    -> include_single_player = True
```

This affected every boolean filter checkbox (single-player, installed-only, exclusive); single-player is just the most visible.

## Fix
Add a hidden `filters_active` marker to the `#filters` form. It's sent on every filter-form submission but absent on a bare page load, which lets the server tell the two apart:

```python
form_submitted = "filters_active" in qp
def flag(name, default):
    if name in qp:
        return qp[name] in ("true", "on", "1")
    return False if form_submitted else default
```

- **Form submitted** (HTMX table fetch / sort): absent checkbox → off.
- **Bare `/games` load**: no marker → saved prefs still apply, so the boxes render in their saved state.

## Tests
Added `tests/test_routes.py` covering: unchecked-overrides-saved-on, checked-turns-on, bare-load-uses-pref, and that the marker applies to all three boolean flags. `just check` green (lint, mypy, 36 tests).

## Note / out of scope
The list-valued filters have the same latent pattern (`qp.getlist("exclude") or prefs[...]`, and the user selection fallback): with all platform-exclude boxes unchecked you can't currently clear a saved exclude list. I kept this PR focused on the reported boolean-toggle bug; happy to extend the `filters_active` logic to those in a follow-up if you want.

🤖 Generated with [Claude Code](https://claude.com/claude-code)