### PR TITLE
Apply filters_active marker to list-valued filters

### DIFF
--- a/src/gamatrix/games/routes.py
+++ b/src/gamatrix/games/routes.py
@@ -36,9 +36,28 @@ def _parse_options(request: Request, user: dict) -> CompareOptions:
     prefs = merge_preferences(user.get("preferences", {}))
     qp = request.query_params
 
-    # User selection: explicit ?user=… params win; otherwise saved preference.
+    # When the filter form is submitted it includes a hidden `filters_active`
+    # marker. An off checkbox — or a list filter with everything deselected —
+    # sends no value, so without this marker we can't tell "user cleared it"
+    # from "not specified". When the form was submitted, an absent value means
+    # empty/off; on a bare page load, fall back to the saved preference.
+    form_submitted = "filters_active" in qp
+
+    def flag(name: str, default: bool) -> bool:
+        if name in qp:
+            return qp[name] in ("true", "on", "1")
+        return False if form_submitted else default
+
+    def multi(name: str, default: list[str]) -> list[str]:
+        values = qp.getlist(name)
+        if values or form_submitted:
+            return values
+        return default
+
+    # User selection: checked `user` boxes win. On a bare load fall back to the
+    # saved preference, expanding the "all" sentinel to every known user.
     selected: list[str] = qp.getlist("user")
-    if not selected:
+    if not selected and not form_submitted:
         pref_users = prefs["selected_users"]
         if pref_users == "all":
             selected = [
@@ -47,23 +66,12 @@ def _parse_options(request: Request, user: dict) -> CompareOptions:
         else:
             selected = list(pref_users)
 
-    # When the filter form is submitted it includes a hidden `filters_active`
-    # marker. An unchecked checkbox sends no value, so without this marker we
-    # can't tell "user turned it off" from "not specified". When the form was
-    # submitted, an absent flag means off; on a bare page load, use the pref.
-    form_submitted = "filters_active" in qp
-
-    def flag(name: str, default: bool) -> bool:
-        if name in qp:
-            return qp[name] in ("true", "on", "1")
-        return False if form_submitted else default
-
     view = qp.get("view", prefs["default_view"])
     return CompareOptions(
         selected_user_ids=selected,
         include_single_player=flag("single_player", prefs["include_single_player"]),
         installed_only=flag("installed_only", prefs["installed_only"]),
-        exclude_platforms=qp.getlist("exclude") or prefs["exclude_platforms"],
+        exclude_platforms=multi("exclude", prefs["exclude_platforms"]),
         exclusive=flag("exclusive", prefs["exclusive"]),
         all_games=view == "grid",
         randomize=flag("randomize", False),

--- a/src/gamatrix/games/routes.py
+++ b/src/gamatrix/games/routes.py
@@ -47,10 +47,16 @@ def _parse_options(request: Request, user: dict) -> CompareOptions:
         else:
             selected = list(pref_users)
 
+    # When the filter form is submitted it includes a hidden `filters_active`
+    # marker. An unchecked checkbox sends no value, so without this marker we
+    # can't tell "user turned it off" from "not specified". When the form was
+    # submitted, an absent flag means off; on a bare page load, use the pref.
+    form_submitted = "filters_active" in qp
+
     def flag(name: str, default: bool) -> bool:
         if name in qp:
             return qp[name] in ("true", "on", "1")
-        return default
+        return False if form_submitted else default
 
     view = qp.get("view", prefs["default_view"])
     return CompareOptions(

--- a/src/gamatrix/templates/games.html.jinja
+++ b/src/gamatrix/templates/games.html.jinja
@@ -20,6 +20,10 @@
       hx-include="#filters"
       class="filters">
 
+    {# Marks requests as coming from the filter form so the server treats an
+       unchecked checkbox as "off" rather than falling back to a saved pref. #}
+    <input type="hidden" name="filters_active" value="1">
+
     <fieldset class="filter-group">
         <legend>Users</legend>
         {% for uid, u in users.items() %}

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,0 +1,56 @@
+"""Tests for request-option parsing in the games routes.
+
+Focus on how `_parse_options` resolves boolean filter checkboxes. An unchecked
+HTML checkbox submits no value, so the filter form sends a hidden
+`filters_active` marker; when present, an absent flag means "off" rather than
+falling back to the user's saved preference.
+"""
+
+from __future__ import annotations
+
+import types
+
+from starlette.datastructures import QueryParams
+
+from gamatrix.games import routes
+
+
+def _opts(query_string: str, preferences: dict):
+    request = types.SimpleNamespace(query_params=QueryParams(query_string))
+    return routes._parse_options(request, {"preferences": preferences})
+
+
+def test_unchecked_box_overrides_saved_on_preference():
+    """Submitting the form with the box unchecked turns the option off even when
+    the saved preference is on (the reported single-player bug)."""
+    prefs = {"include_single_player": True, "selected_users": ["1"]}
+    opts = _opts("user=1&filters_active=1", prefs)
+    assert opts.include_single_player is False
+
+
+def test_checked_box_turns_option_on():
+    prefs = {"include_single_player": False, "selected_users": ["1"]}
+    opts = _opts("user=1&filters_active=1&single_player=true", prefs)
+    assert opts.include_single_player is True
+
+
+def test_bare_page_load_uses_saved_preference():
+    """A bare /games load (no filter form submitted) still honors saved prefs."""
+    prefs = {"include_single_player": True, "selected_users": ["1"]}
+    opts = _opts("user=1", prefs)
+    assert opts.include_single_player is True
+
+
+def test_marker_applies_to_all_boolean_flags():
+    """All boolean filter checkboxes share the same resolution, so an absent one
+    on a submitted form is off regardless of saved prefs."""
+    prefs = {
+        "include_single_player": True,
+        "installed_only": True,
+        "exclusive": True,
+        "selected_users": ["1"],
+    }
+    opts = _opts("user=1&filters_active=1", prefs)
+    assert opts.include_single_player is False
+    assert opts.installed_only is False
+    assert opts.exclusive is False

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -54,3 +54,37 @@ def test_marker_applies_to_all_boolean_flags():
     assert opts.include_single_player is False
     assert opts.installed_only is False
     assert opts.exclusive is False
+
+
+def test_emptied_exclude_list_clears_saved_pref():
+    """Submitting with every platform-exclude box unchecked clears the saved
+    exclude list instead of falling back to it."""
+    prefs = {"exclude_platforms": ["gog", "epic"], "selected_users": ["1"]}
+    opts = _opts("user=1&filters_active=1", prefs)
+    assert opts.exclude_platforms == []
+
+
+def test_partial_exclude_list_wins_over_saved_pref():
+    prefs = {"exclude_platforms": ["gog", "epic"], "selected_users": ["1"]}
+    opts = _opts("user=1&filters_active=1&exclude=gog", prefs)
+    assert opts.exclude_platforms == ["gog"]
+
+
+def test_bare_load_uses_saved_exclude_list():
+    prefs = {"exclude_platforms": ["gog", "epic"], "selected_users": ["1"]}
+    opts = _opts("user=1", prefs)
+    assert opts.exclude_platforms == ["gog", "epic"]
+
+
+def test_deselecting_all_users_shows_none_on_submit():
+    """Submitting with no user boxes checked yields an empty selection rather
+    than falling back to the saved users (and without hitting the repo)."""
+    prefs = {"selected_users": ["1", "2"], "exclude_platforms": []}
+    opts = _opts("filters_active=1", prefs)
+    assert opts.selected_user_ids == []
+
+
+def test_bare_load_uses_saved_user_selection():
+    prefs = {"selected_users": ["1", "2"], "exclude_platforms": []}
+    opts = _opts("", prefs)
+    assert opts.selected_user_ids == ["1", "2"]


### PR DESCRIPTION
Follow-up to #140. That PR fixed the **boolean** filter checkboxes; this extends the same `filters_active` marker to the **list-valued** filters, which had the identical latent bug.

## Problem
`_parse_options` resolved list filters as `qp.getlist(name) or prefs[name]`, so an empty submitted list fell back to the saved preference. Practical effects:
- Unchecking **all** platform-exclude boxes couldn't clear a saved exclude list.
- Deselecting **all** users silently reselected the saved set instead of showing nothing.

## Fix
Add a `multi()` helper mirroring `flag()` from #140:

```python
def multi(name, default):
    values = qp.getlist(name)
    if values or form_submitted:
        return values   # submitted form: empty means explicitly empty
    return default       # bare load: use saved pref
```

- `exclude_platforms` now uses `multi("exclude", prefs["exclude_platforms"])`.
- The user-selection fallback is gated on `not form_submitted`, so deselecting everyone yields an empty selection — and skips the `scan_users()` call that the fallback would otherwise make.

## Tests
Added cases to `tests/test_routes.py`: emptied exclude clears / partial exclude wins / bare-load uses saved exclude; deselect-all-users → empty on submit / bare-load uses saved users. `just check` green (lint, mypy, 41 tests).

## Note
Based on the #140 branch so the diff is just the follow-up. Once #140 merges, I'll retarget this to `master` (or it can be merged after #140).

🤖 Generated with [Claude Code](https://claude.com/claude-code)