### PR TITLE
Fix just deploy: install cdk extra into .venv

### DIFF
--- a/infrastructure/cdk/README.md
+++ b/infrastructure/cdk/README.md
@@ -10,16 +10,22 @@ AWS CDK (Python) stack for gamatrix v2.
 
 ## Install
 
+`cdk.json` runs the app with the project venv (`../../.venv/bin/python`), so the
+`cdk` extra has to be installed there. Sync it together with `dev` so a later
+`uv sync` (e.g. `just install`) doesn't prune it back out:
+
 ```bash
-uv pip install -e ".[cdk]"   # from the repo root
+uv sync --extra dev --extra cdk   # from the repo root
 ```
 
 ## Deploy
 
+`just deploy` runs the sync above before deploying. To run CDK directly:
+
 ```bash
 cd infrastructure/cdk
-cdk bootstrap      # first time in an account/region
-cdk deploy
+npx cdk bootstrap   # first time in an account/region
+npx cdk deploy
 ```
 
 ## What it creates

--- a/justfile
+++ b/justfile
@@ -58,6 +58,10 @@ build:
 
 # Deploy infrastructure with CDK
 deploy:
+  # cdk.json runs the app via ../../.venv/bin/python, so the cdk extra must be
+  # present in .venv. `uv sync` prunes anything outside the synced set, so sync
+  # dev + cdk together to keep the dev tools too.
+  uv sync --extra dev --extra cdk
   cd infrastructure/cdk && CDK_DEFAULT_REGION=ca-central-1 npx cdk deploy --region ca-central-1
 
 # Store IGDB API credentials in Secrets Manager


### PR DESCRIPTION
## Problem
`just deploy` fails with:
```
ModuleNotFoundError: No module named 'aws_cdk'
```

## Root cause
`infrastructure/cdk/cdk.json` runs the CDK app with the project venv:
```json
"app": "../../.venv/bin/python app.py"
```
But `.venv` is built by `just install` → `uv sync --extra dev`, which **doesn't** include the `cdk` extra (where `aws-cdk-lib` lives). And `uv sync` prunes anything outside the synced set, so the README's manual `uv pip install -e ".[cdk]"` gets removed by the next `uv sync` (`just install`/`dev`/`up`). So `app.py`'s `import aws_cdk` fails.

## Fix
- `just deploy` now runs `uv sync --extra dev --extra cdk` before invoking CDK, guaranteeing `aws-cdk-lib` is in `.venv` (and keeping the dev tools so the deploy doesn't gut the dev environment).
- Updated `infrastructure/cdk/README.md` to document syncing the extra (`uv sync --extra dev --extra cdk`) instead of the prunable `uv pip install -e ".[cdk]"`, and to use `npx cdk` consistently.

## Verification
After `uv sync --extra dev --extra cdk`, the interpreter cdk.json uses imports cleanly:
```
$ .venv/bin/python -c "import aws_cdk, constructs, yaml; ..."
aws-cdk-lib 2.173.4
all CDK imports OK
```
Running the stack now gets past import all the way to a CDK *runtime* hosted-zone lookup (which needs AWS account/region/credentials) — i.e. the module error is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)