### PR TITLE
Fix stuck enrichment progress bar and inaccurate counts (#131)

### DIFF
--- a/src/gamatrix/constants.py
+++ b/src/gamatrix/constants.py
@@ -61,3 +61,9 @@ JOB_PENDING = "pending"
 JOB_RUNNING = "running"
 JOB_COMPLETED = "completed"
 JOB_FAILED = "failed"
+
+# A pending/running job with no progress for this long is presumed dead (the
+# enricher Lambda crashed or hit its hard timeout without recording a terminal
+# status). Past this it stops driving the UI. Kept above the enricher's 15-min
+# Lambda timeout so a slow-but-live job isn't reaped mid-run.
+JOB_TIMEOUT_MINUTES = 20

--- a/src/gamatrix/games/routes.py
+++ b/src/gamatrix/games/routes.py
@@ -175,7 +175,9 @@ def job_status(
 ):
     job = repo.get_job(job_id)
     done = (
-        job is None or job["status"] in (JOB_COMPLETED, JOB_FAILED) or is_job_stale(job)
+        job is None
+        or job.get("status") in (JOB_COMPLETED, JOB_FAILED)
+        or is_job_stale(job)
     )
     return templates.TemplateResponse(
         request,

--- a/src/gamatrix/games/routes.py
+++ b/src/gamatrix/games/routes.py
@@ -22,7 +22,7 @@ from gamatrix.games import service
 from gamatrix.games.preferences import merge_preferences
 from gamatrix.games.service import CompareOptions
 from gamatrix.helpers import parse_iso
-from gamatrix.jobs import create_enrichment_job
+from gamatrix.jobs import create_enrichment_job, is_job_stale
 from gamatrix.storage.dynamo import Repository
 from gamatrix.storage.queue import get_queue
 from gamatrix.templating import templates
@@ -174,7 +174,9 @@ def job_status(
     repo: Repository = Depends(get_repo),
 ):
     job = repo.get_job(job_id)
-    done = job is None or job["status"] in (JOB_COMPLETED, JOB_FAILED)
+    done = (
+        job is None or job["status"] in (JOB_COMPLETED, JOB_FAILED) or is_job_stale(job)
+    )
     return templates.TemplateResponse(
         request,
         "job_status.html.jinja",

--- a/src/gamatrix/igdb/enricher.py
+++ b/src/gamatrix/igdb/enricher.py
@@ -34,7 +34,7 @@ async def run_job(
         return
 
     repo.update_job(job_id, {"status": JOB_RUNNING, "updated_at": now_iso()})
-    release_keys: list[str] = job["release_keys"]
+    release_keys: list[str] = job.get("release_keys", [])
 
     # Group release keys by the IGDB key so games shared across platforms
     # (e.g. a Steam and a GOG copy) only cost one set of API calls.

--- a/src/gamatrix/igdb/enricher.py
+++ b/src/gamatrix/igdb/enricher.py
@@ -33,7 +33,7 @@ async def run_job(
         log.error("Enrichment job %s not found", job_id)
         return
 
-    repo.update_job(job_id, {"status": JOB_RUNNING})
+    repo.update_job(job_id, {"status": JOB_RUNNING, "updated_at": now_iso()})
     release_keys: list[str] = job["release_keys"]
 
     # Group release keys by the IGDB key so games shared across platforms
@@ -49,6 +49,7 @@ async def run_job(
         by_igdb_key.setdefault(game["igdb_key"], []).append(rk)
 
     client_id, client_secret = resolve_igdb_credentials(settings)
+    completed = 0
     try:
         async with IGDBClient(client_id, client_secret) as client:
             for igdb_key, rks in by_igdb_key.items():
@@ -61,7 +62,11 @@ async def run_job(
                     meta = GameMetadata()
                 for rk in rks:
                     _write_metadata(repo, games[rk], meta)
-                    repo.increment_job_progress(job_id, 1)
+                    completed += 1
+                    # Absolute, not incremental: a redelivered or concurrent
+                    # run converges here instead of pushing the count past
+                    # `total` (see #131).
+                    repo.set_job_progress(job_id, completed)
     except Exception:
         log.exception("Enrichment job %s failed", job_id)
         repo.update_job(job_id, {"status": JOB_FAILED, "completed_at": now_iso()})

--- a/src/gamatrix/jobs.py
+++ b/src/gamatrix/jobs.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import uuid
 from datetime import datetime, timedelta, timezone
+from typing import NotRequired, TypedDict
 
 from gamatrix.constants import (
     JOB_PENDING,
@@ -18,12 +19,30 @@ from gamatrix.storage.queue import EnrichmentQueue
 log = logging.getLogger(__name__)
 
 
-def is_job_active(job: dict) -> bool:
+class JobRecord(TypedDict):
+    """An enrichment job row in the `enrichment_jobs` table.
+
+    Documents the shape the helpers and routes assume so a missing or renamed
+    field is a type error rather than a `KeyError` at runtime. `updated_at` is
+    absent until the enricher records its first progress, so a freshly created
+    job carries only `created_at` (which `is_job_stale` falls back to)."""
+
+    job_id: str
+    status: str
+    created_at: str
+    completed_at: str | None
+    release_keys: list[str]
+    total: int
+    completed_count: int
+    updated_at: NotRequired[str]
+
+
+def is_job_active(job: JobRecord) -> bool:
     """True while a job is still pending or running (not yet terminal)."""
     return job.get("status") in (JOB_PENDING, JOB_RUNNING)
 
 
-def is_job_stale(job: dict) -> bool:
+def is_job_stale(job: JobRecord) -> bool:
     """True for an active job that has made no progress within the timeout.
 
     Such a job is presumed dead — the enricher Lambda crashed or hit its hard
@@ -52,17 +71,16 @@ def create_enrichment_job(
         return None
 
     job_id = str(uuid.uuid4())
-    repo.put_job(
-        {
-            "job_id": job_id,
-            "status": JOB_PENDING,
-            "created_at": now_iso(),
-            "completed_at": None,
-            "release_keys": release_keys,
-            "total": len(release_keys),
-            "completed_count": 0,
-        }
-    )
+    job: JobRecord = {
+        "job_id": job_id,
+        "status": JOB_PENDING,
+        "created_at": now_iso(),
+        "completed_at": None,
+        "release_keys": release_keys,
+        "total": len(release_keys),
+        "completed_count": 0,
+    }
+    repo.put_job(job)
     queue.enqueue(job_id)
     log.info("Created enrichment job %s for %d games", job_id, len(release_keys))
     return job_id

--- a/src/gamatrix/jobs.py
+++ b/src/gamatrix/jobs.py
@@ -4,13 +4,40 @@ from __future__ import annotations
 
 import logging
 import uuid
+from datetime import datetime, timedelta, timezone
 
-from gamatrix.constants import JOB_PENDING
-from gamatrix.helpers import now_iso
+from gamatrix.constants import (
+    JOB_PENDING,
+    JOB_RUNNING,
+    JOB_TIMEOUT_MINUTES,
+)
+from gamatrix.helpers import now_iso, parse_iso
 from gamatrix.storage.dynamo import Repository
 from gamatrix.storage.queue import EnrichmentQueue
 
 log = logging.getLogger(__name__)
+
+
+def is_job_active(job: dict) -> bool:
+    """True while a job is still pending or running (not yet terminal)."""
+    return job.get("status") in (JOB_PENDING, JOB_RUNNING)
+
+
+def is_job_stale(job: dict) -> bool:
+    """True for an active job that has made no progress within the timeout.
+
+    Such a job is presumed dead — the enricher Lambda crashed or hit its hard
+    timeout without writing a terminal status — so the UI should treat it as
+    finished rather than poll it forever. Staleness is measured from the last
+    progress (`updated_at`), falling back to `created_at` for a job that never
+    progressed."""
+    if not is_job_active(job):
+        return False
+    last_seen = job.get("updated_at") or job.get("created_at")
+    if not last_seen:
+        return False
+    cutoff = datetime.now(timezone.utc) - timedelta(minutes=JOB_TIMEOUT_MINUTES)
+    return parse_iso(last_seen) < cutoff
 
 
 def create_enrichment_job(

--- a/src/gamatrix/storage/dynamo.py
+++ b/src/gamatrix/storage/dynamo.py
@@ -8,13 +8,17 @@ dynamodb-local in development; only the endpoint URL differs.
 from __future__ import annotations
 
 import decimal
-from typing import Any, Iterable
+from typing import TYPE_CHECKING, Any, Iterable, cast
 
 import boto3
 from boto3.dynamodb.conditions import Key
 
 from gamatrix.config import Settings, get_settings
 from gamatrix.helpers import now_iso
+
+if TYPE_CHECKING:
+    # Annotation-only; importing at runtime would cycle (jobs imports Repository).
+    from gamatrix.jobs import JobRecord
 
 
 def _to_dynamo(value: Any) -> Any:
@@ -160,10 +164,10 @@ class Repository:
     # ------------------------------------------------------------------
     # enrichment_jobs
     # ------------------------------------------------------------------
-    def put_job(self, job: dict) -> None:
+    def put_job(self, job: JobRecord) -> None:
         self._table(self.settings.jobs_table).put_item(Item=_to_dynamo(job))
 
-    def get_job(self, job_id: str) -> dict | None:
+    def get_job(self, job_id: str) -> JobRecord | None:
         resp = self._table(self.settings.jobs_table).get_item(Key={"job_id": job_id})
         item = resp.get("Item")
         return _from_dynamo(item) if item else None
@@ -198,19 +202,18 @@ class Repository:
             if j.get("status") == JOB_PENDING
         ]
 
-    def get_active_job(self) -> dict | None:
+    def get_active_job(self) -> JobRecord | None:
         """Return the most recently created pending-or-running job, if any.
 
         Stale jobs (presumed-dead enrichers, see `is_job_stale`) are skipped so
         a job that never reached a terminal status can't pin the progress bar
         on every page load, nor block new enrichment from being queued."""
+        # Imported here, not at module scope: gamatrix.jobs imports Repository
+        # from this module, so a top-level import would be circular.
         from gamatrix.jobs import is_job_active, is_job_stale
 
-        active = [
-            j
-            for j in self._scan(self.settings.jobs_table)
-            if is_job_active(j) and not is_job_stale(j)
-        ]
+        jobs = cast("list[JobRecord]", self._scan(self.settings.jobs_table))
+        active = [j for j in jobs if is_job_active(j) and not is_job_stale(j)]
         if not active:
             return None
         return max(active, key=lambda j: j.get("created_at", ""))

--- a/src/gamatrix/storage/dynamo.py
+++ b/src/gamatrix/storage/dynamo.py
@@ -14,6 +14,7 @@ import boto3
 from boto3.dynamodb.conditions import Key
 
 from gamatrix.config import Settings, get_settings
+from gamatrix.helpers import now_iso
 
 
 def _to_dynamo(value: Any) -> Any:
@@ -178,11 +179,14 @@ class Repository:
             ExpressionAttributeValues=values,
         )
 
-    def increment_job_progress(self, job_id: str, by: int = 1) -> None:
-        self._table(self.settings.jobs_table).update_item(
-            Key={"job_id": job_id},
-            UpdateExpression="SET completed_count = completed_count + :n",
-            ExpressionAttributeValues={":n": _to_dynamo(by)},
+    def set_job_progress(self, job_id: str, completed_count: int) -> None:
+        """Record absolute progress. Idempotent across SQS redeliveries: a
+        retried or concurrently-running enricher converges on the same value
+        instead of inflating an atomic counter past `total` (see #131). Also
+        stamps `updated_at` so staleness is measured from the last progress,
+        not job creation."""
+        self.update_job(
+            job_id, {"completed_count": completed_count, "updated_at": now_iso()}
         )
 
     def list_pending_jobs(self) -> list[dict]:
@@ -195,13 +199,17 @@ class Repository:
         ]
 
     def get_active_job(self) -> dict | None:
-        """Return the most recently created pending-or-running job, if any."""
-        from gamatrix.constants import JOB_PENDING, JOB_RUNNING
+        """Return the most recently created pending-or-running job, if any.
+
+        Stale jobs (presumed-dead enrichers, see `is_job_stale`) are skipped so
+        a job that never reached a terminal status can't pin the progress bar
+        on every page load, nor block new enrichment from being queued."""
+        from gamatrix.jobs import is_job_active, is_job_stale
 
         active = [
             j
             for j in self._scan(self.settings.jobs_table)
-            if j.get("status") in (JOB_PENDING, JOB_RUNNING)
+            if is_job_active(j) and not is_job_stale(j)
         ]
         if not active:
             return None

--- a/src/gamatrix/templates/job_status.html.jinja
+++ b/src/gamatrix/templates/job_status.html.jinja
@@ -9,7 +9,9 @@
     </div>
 {% else %}
     {% set total = job.total|default(1) %}
-    {% set done_count = job.completed_count|default(0) %}
+    {# Clamp: progress should never exceed total, but guard the display in case
+       a job's count was inflated by a retry before it settled (see #131). #}
+    {% set done_count = [job.completed_count|default(0), total]|min %}
     {% set pct = (done_count * 100 // total) if total else 0 %}
     <div class="job-progress"
          hx-get="/api/jobs/{{ job_id }}"

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -1,0 +1,108 @@
+"""Tests for enrichment job progress and staleness handling.
+
+Covers the two failure modes behind the stuck progress bar and #131's
+inaccurate counts: a job left non-terminal must stop driving the UI, and
+progress must stay idempotent across SQS redeliveries / concurrent runs.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from gamatrix.constants import (
+    JOB_COMPLETED,
+    JOB_PENDING,
+    JOB_RUNNING,
+    JOB_TIMEOUT_MINUTES,
+)
+from gamatrix.helpers import now_iso
+from gamatrix.jobs import is_job_active, is_job_stale
+
+
+def _ago(minutes: int) -> str:
+    return (datetime.now(timezone.utc) - timedelta(minutes=minutes)).isoformat()
+
+
+def _job(repo, **overrides):
+    job = {
+        "job_id": overrides.get("job_id", "j1"),
+        "status": JOB_RUNNING,
+        "created_at": now_iso(),
+        "completed_at": None,
+        "release_keys": ["steam_1", "steam_2"],
+        "total": 2,
+        "completed_count": 0,
+    }
+    job.update(overrides)
+    repo.put_job(job)
+    return job
+
+
+def test_is_job_active():
+    assert is_job_active({"status": JOB_PENDING})
+    assert is_job_active({"status": JOB_RUNNING})
+    assert not is_job_active({"status": JOB_COMPLETED})
+    assert not is_job_active({"status": "failed"})
+
+
+def test_fresh_running_job_is_not_stale():
+    assert not is_job_stale({"status": JOB_RUNNING, "updated_at": now_iso()})
+
+
+def test_old_running_job_is_stale():
+    job = {"status": JOB_RUNNING, "updated_at": _ago(JOB_TIMEOUT_MINUTES + 1)}
+    assert is_job_stale(job)
+
+
+def test_terminal_job_is_never_stale():
+    # Completed jobs aren't "active", so staleness doesn't apply even if old.
+    assert not is_job_stale({"status": JOB_COMPLETED, "updated_at": _ago(999)})
+
+
+def test_staleness_measured_from_progress_not_creation():
+    # A long-running job that created hours ago but is still making progress
+    # must not be reaped.
+    job = {
+        "status": JOB_RUNNING,
+        "created_at": _ago(120),
+        "updated_at": _ago(1),
+    }
+    assert not is_job_stale(job)
+
+
+def test_staleness_falls_back_to_created_at():
+    # A job that started running but never recorded progress.
+    job = {"status": JOB_RUNNING, "created_at": _ago(JOB_TIMEOUT_MINUTES + 1)}
+    assert is_job_stale(job)
+
+
+def test_get_active_job_skips_stale(repo):
+    _job(repo, job_id="dead", updated_at=_ago(JOB_TIMEOUT_MINUTES + 5))
+    assert repo.get_active_job() is None
+
+
+def test_get_active_job_returns_fresh(repo):
+    _job(repo, job_id="live", updated_at=now_iso())
+    active = repo.get_active_job()
+    assert active is not None
+    assert active["job_id"] == "live"
+
+
+def test_get_active_job_prefers_fresh_over_stale(repo):
+    _job(repo, job_id="dead", created_at=_ago(60), updated_at=_ago(60))
+    _job(repo, job_id="live", created_at=now_iso(), updated_at=now_iso())
+    active = repo.get_active_job()
+    assert active["job_id"] == "live"
+
+
+def test_set_job_progress_is_absolute_and_idempotent(repo):
+    _job(repo, job_id="j1", completed_count=0)
+    repo.set_job_progress("j1", 1)
+    repo.set_job_progress("j1", 2)
+    # A redelivered run replays the same values; the count must not climb past
+    # what it sets, unlike an atomic increment (see #131).
+    repo.set_job_progress("j1", 1)
+    repo.set_job_progress("j1", 2)
+    job = repo.get_job("j1")
+    assert job["completed_count"] == 2
+    assert job["updated_at"]


### PR DESCRIPTION
## Problem

Two symptoms with one root cause: a job that never reaches a terminal status.

- **Stuck "Updating game data from IGDB…" bar.** It's not a cookie — the job id is re-derived on every `/games` load via `repo.get_active_job()`, which scans **all** jobs globally and returns any still `pending`/`running`. When the enricher Lambda crashes or hits its hard 15-min timeout, the `try/except` in `run_job` doesn't fire, so the job stays `running` forever. That one ghost job then re-attaches the progress bar on every page load, **for every user**, and blocks new enrichment from queueing.
- **Inaccurate counts (#131), e.g. `874 / 225`.** SQS is at-least-once. A job that runs longer than the 16-min visibility timeout (a big, rate-limited library) gets redelivered and re-runs concurrently. The progress write was an atomic `completed_count = completed_count + 1`, never reset, so overlapping runs pushed the count well past `total`.

## Fixes (app code)

- **Idempotent progress.** `increment_job_progress` → `set_job_progress(job_id, completed)` writes an **absolute** value from a locally-tracked counter, so redelivered/concurrent runs converge instead of inflating. It also stamps `updated_at`.
- **Staleness.** New `is_job_active` / `is_job_stale` helpers: an active job with no progress within `JOB_TIMEOUT_MINUTES` (20, above the 15-min enricher cap) is presumed dead. Measured from **last progress** (`updated_at`), not creation, so a slow-but-live job isn't reaped mid-run.
- `get_active_job()` skips stale jobs, so a ghost job can't pin the bar or block new enrichment.
- `job_status` route treats a stale job as `done`, so an already-displayed bar self-clears on its next 3s poll without a reload.
- Template clamps the rendered count to `total` as a display backstop.

## Tests

New `tests/test_jobs.py` (10 cases): active/stale classification, staleness measured from progress vs. creation, `get_active_job` skipping stale jobs, idempotent progress. Full suite **53 passed**; lint + typecheck clean.

## Follow-up

Infra backstop — DLQ + `maxReceiveCount` on `EnrichmentQueue` — will land in a separate PR. This PR does not actively flip stale jobs to `failed` in DynamoDB (they just age out of `get_active_job`); self-healing can ride along with the infra PR if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)