### PR TITLE
Allow users to edit their display name

### DIFF
--- a/src/gamatrix/constants.py
+++ b/src/gamatrix/constants.py
@@ -4,6 +4,9 @@
 UPLOAD_ALLOWED_EXTENSIONS = ["db"]
 UPLOAD_MAX_SIZE = 300 * 1024 * 1024
 
+# Bounds for a user-chosen display name (the `username` field).
+DISPLAY_NAME_MAX_LENGTH = 32
+
 # Full mapping is at https://api-docs.igdb.com/#external-game-enums, but only
 # Steam and GOG actually work; the other platforms' IDs don't match IGDB.
 IGDB_PLATFORM_ID = {

--- a/src/gamatrix/preferences.py
+++ b/src/gamatrix/preferences.py
@@ -3,14 +3,31 @@
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends, Request
-from fastapi.responses import HTMLResponse, Response
+from fastapi.responses import HTMLResponse, JSONResponse, Response
 
 from gamatrix.auth.dependencies import current_user, current_user_api, get_repo
+from gamatrix.constants import DISPLAY_NAME_MAX_LENGTH
 from gamatrix.games.preferences import merge_preferences
 from gamatrix.storage.dynamo import Repository
 from gamatrix.templating import templates
 
 router = APIRouter(tags=["preferences"])
+
+
+def clean_display_name(raw: str) -> str:
+    """Validate and normalize a user-supplied display name.
+
+    Collapses surrounding whitespace and enforces non-empty / max-length.
+    Raises ValueError with a user-facing message if it doesn't qualify.
+    """
+    name = " ".join((raw or "").split())
+    if not name:
+        raise ValueError("Display name cannot be empty.")
+    if len(name) > DISPLAY_NAME_MAX_LENGTH:
+        raise ValueError(
+            f"Display name must be {DISPLAY_NAME_MAX_LENGTH} characters or fewer."
+        )
+    return name
 
 
 @router.get("/preferences", response_class=HTMLResponse)
@@ -58,3 +75,19 @@ async def save_preferences(
     }
     repo.update_user(user["email"], {"preferences": prefs})
     return Response(status_code=204)
+
+
+@router.post("/profile")
+async def save_profile(
+    request: Request,
+    user: dict = Depends(current_user_api),
+    repo: Repository = Depends(get_repo),
+):
+    """Update the signed-in user's display name."""
+    form = await request.form()
+    try:
+        name = clean_display_name(str(form.get("username", "")))
+    except ValueError as exc:
+        return JSONResponse({"error": str(exc)}, status_code=400)
+    repo.update_user(user["email"], {"username": name})
+    return JSONResponse({"username": name})

--- a/src/gamatrix/templates/preferences.html.jinja
+++ b/src/gamatrix/templates/preferences.html.jinja
@@ -6,6 +6,21 @@
     <div class="right"><a href="/games">Back to games</a></div>
 </div>
 
+<form id="profile" method="post" action="/profile" class="filters"
+      hx-post="/profile" hx-swap="none"
+      hx-on::after-request="if(event.detail.successful){this.querySelector('.saved').style.display='inline';this.querySelector('.error').style.display='none'}else{const e=this.querySelector('.error');e.textContent=JSON.parse(event.detail.xhr.responseText).error;e.style.display='inline';this.querySelector('.saved').style.display='none'}">
+    <fieldset class="filter-group">
+        <legend>Display name</legend>
+        <label>
+            <input type="text" name="username" value="{{ user.username }}"
+                   maxlength="32" required>
+        </label>
+        <button type="submit">Save name</button>
+        <span class="saved muted" style="display:none;">Saved ✓</span>
+        <span class="error" style="display:none;color:#c00;"></span>
+    </fieldset>
+</form>
+
 <form id="filters" method="post" action="/preferences" class="filters"
       hx-post="/preferences" hx-swap="none"
       hx-on::after-request="this.querySelector('.saved').style.display='inline'">

--- a/tests/test_preferences.py
+++ b/tests/test_preferences.py
@@ -1,0 +1,29 @@
+"""Tests for display-name validation and the profile-save endpoint."""
+
+from __future__ import annotations
+
+import pytest
+
+from gamatrix import preferences
+from gamatrix.constants import DISPLAY_NAME_MAX_LENGTH
+
+
+def test_clean_display_name_trims_and_collapses_whitespace():
+    assert preferences.clean_display_name("  Erik   Niklas  ") == "Erik Niklas"
+
+
+def test_clean_display_name_rejects_empty():
+    with pytest.raises(ValueError, match="empty"):
+        preferences.clean_display_name("   ")
+
+
+def test_clean_display_name_rejects_too_long():
+    with pytest.raises(ValueError, match="characters or fewer"):
+        preferences.clean_display_name("x" * (DISPLAY_NAME_MAX_LENGTH + 1))
+
+
+def test_save_profile_persists_username(repo):
+    repo.put_user({"email": "user@x.com", "username": "Old", "user_id": "1"})
+    name = preferences.clean_display_name(" New ")
+    repo.update_user("user@x.com", {"username": name})
+    assert repo.get_user("user@x.com")["username"] == "New"


### PR DESCRIPTION
Part of #133 (display-name half; profile-pic upload deferred — see below).

## What

Adds a **Display name** form to the preferences page so a signed-in user can change their `username`.

- New `POST /profile` endpoint validates and normalizes the input — trims/collapses whitespace, rejects empty, caps at `DISPLAY_NAME_MAX_LENGTH` (32) — then persists via `update_user`.
- `username` is read live everywhere through `scan_users()`, so the new name shows up across the games/preferences views immediately with no other changes.
- HTMX form shows inline "Saved ✓" / validation error without a page reload.

## Tests

`tests/test_preferences.py` covers the validation helper (`clean_display_name`) and the persisted update. `just check` (black + flake8 + mypy + pytest) passes.

## Why profile pics are deferred (the architectural note from #133)

Today profile pics are static `.png` files committed to the repo and served from `/static/profile_img/` (`games_table.html.jinja:25`). On Lambda that directory is **baked into the read-only container image**, so user-uploaded pics can't be written there. Supporting uploads requires:

- storing pics in S3 (the existing upload bucket under a non-`uploads/` prefix, so they don't trip the parser-Lambda S3 trigger filtered to `prefix="uploads/"` in `gamatrix_stack.py`), and
- a serving path — a `/profile_img/{user_id}` web route that streams from S3 with cache headers (the agreed approach), plus a through-Lambda multipart upload that validates/resizes.

That's a meaningfully larger change, so it's tracked as a follow-up rather than bundled here. Display-name editing is the trivial, self-contained half and ships first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)