### PR TITLE
Allow users to upload a profile picture

### DIFF
--- a/infrastructure/cdk/gamatrix_stack.py
+++ b/infrastructure/cdk/gamatrix_stack.py
@@ -327,6 +327,7 @@ class GamatrixStack(Stack):
         )
         table("enrichment_jobs", "job_id")
         table("metadata_overrides", "slug")
+        table("profile_pics", "user_id")
         table("config", "key")
         return tables
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
     "pydantic-settings==2.7.1",
     "rapidfuzz==3.11.0",
     "itsdangerous==2.2.0",
+    "pillow==11.1.0",
 ]
 
 [project.optional-dependencies]

--- a/scripts/init_local.py
+++ b/scripts/init_local.py
@@ -64,6 +64,13 @@ def _table_defs(s):
             "AttributeDefinitions": [{"AttributeName": "slug", "AttributeType": "S"}],
         },
         {
+            "TableName": s.profile_pics_table,
+            "KeySchema": [{"AttributeName": "user_id", "KeyType": "HASH"}],
+            "AttributeDefinitions": [
+                {"AttributeName": "user_id", "AttributeType": "S"}
+            ],
+        },
+        {
             "TableName": s.config_table,
             "KeySchema": [{"AttributeName": "key", "KeyType": "HASH"}],
             "AttributeDefinitions": [{"AttributeName": "key", "AttributeType": "S"}],

--- a/src/gamatrix/config.py
+++ b/src/gamatrix/config.py
@@ -91,6 +91,11 @@ class Settings(BaseSettings):
         return f"{self.table_prefix}_metadata_overrides"
 
     @property
+    def profile_pics_table(self) -> str:
+        """Holds user-uploaded profile-pic bytes, keyed by user_id."""
+        return f"{self.table_prefix}_profile_pics"
+
+    @property
     def config_table(self) -> str:
         """Small key/value table; locally holds the hidden/single-player lists."""
         return f"{self.table_prefix}_config"

--- a/src/gamatrix/constants.py
+++ b/src/gamatrix/constants.py
@@ -10,6 +10,11 @@ DISPLAY_NAME_MAX_LENGTH = 32
 # Profile pictures: max accepted upload, and the output thumbnail box (px).
 PROFILE_PIC_MAX_UPLOAD_SIZE = 5 * 1024 * 1024
 PROFILE_PIC_SIZE = 128
+# Reject images whose decoded pixel count exceeds this before fully decoding.
+# A small file can decompress to an enormous bitmap (a "decompression bomb")
+# that exhausts a worker's CPU/RAM; the byte cap above does not protect against
+# it. 50 MP comfortably clears legitimate phone/camera uploads.
+PROFILE_PIC_MAX_INPUT_PIXELS = 50_000_000
 
 # Full mapping is at https://api-docs.igdb.com/#external-game-enums, but only
 # Steam and GOG actually work; the other platforms' IDs don't match IGDB.

--- a/src/gamatrix/constants.py
+++ b/src/gamatrix/constants.py
@@ -7,6 +7,10 @@ UPLOAD_MAX_SIZE = 300 * 1024 * 1024
 # Bounds for a user-chosen display name (the `username` field).
 DISPLAY_NAME_MAX_LENGTH = 32
 
+# Profile pictures: max accepted upload, and the output thumbnail box (px).
+PROFILE_PIC_MAX_UPLOAD_SIZE = 5 * 1024 * 1024
+PROFILE_PIC_SIZE = 128
+
 # Full mapping is at https://api-docs.igdb.com/#external-game-enums, but only
 # Steam and GOG actually work; the other platforms' IDs don't match IGDB.
 IGDB_PLATFORM_ID = {

--- a/src/gamatrix/helpers.py
+++ b/src/gamatrix/helpers.py
@@ -33,12 +33,13 @@ def get_slug_from_title(title: str) -> str:
 def pic_url(user: dict) -> str | None:
     """Resolve a user's profile-picture URL, or None if they have no pic.
 
-    A user-uploaded pic lives in S3 and is served by the /profile_img route
-    (keyed by user_id, with a cache-busting ?v= from the last update). A seeded
-    pic is a static file committed under static/profile_img/.
+    A user-uploaded pic lives in DynamoDB and is served by the /profile_img
+    route (keyed by user_id, with a cache-busting ?v= from the last update).
+    `pic_updated` (an epoch set on upload) doubles as the "has an upload" flag.
+    A seeded pic is a static file committed under static/profile_img/.
     """
-    if user.get("pic_key") and user.get("user_id"):
-        return f"/profile_img/{user['user_id']}?v={user.get('pic_updated', '')}"
+    if user.get("pic_updated") and user.get("user_id"):
+        return f"/profile_img/{user['user_id']}?v={user['pic_updated']}"
     if user.get("pic"):
         return f"/static/profile_img/{user['pic']}"
     return None

--- a/src/gamatrix/helpers.py
+++ b/src/gamatrix/helpers.py
@@ -30,6 +30,20 @@ def get_slug_from_title(title: str) -> str:
     return slug.strip("-")
 
 
+def pic_url(user: dict) -> str | None:
+    """Resolve a user's profile-picture URL, or None if they have no pic.
+
+    A user-uploaded pic lives in S3 and is served by the /profile_img route
+    (keyed by user_id, with a cache-busting ?v= from the last update). A seeded
+    pic is a static file committed under static/profile_img/.
+    """
+    if user.get("pic_key") and user.get("user_id"):
+        return f"/profile_img/{user['user_id']}?v={user.get('pic_updated', '')}"
+    if user.get("pic"):
+        return f"/static/profile_img/{user['pic']}"
+    return None
+
+
 def now_iso() -> str:
     """Current UTC time as an ISO 8601 string."""
     return datetime.now(timezone.utc).isoformat()

--- a/src/gamatrix/images.py
+++ b/src/gamatrix/images.py
@@ -1,9 +1,14 @@
 """Profile-picture image processing.
 
-User-uploaded images are normalized server-side before they reach S3: decoded
+User-uploaded images are normalized server-side before they are stored: decoded
 (which validates that the bytes really are an image), flattened onto a
 transparent canvas, downscaled to a small square-ish thumbnail, and re-encoded
 as PNG. Re-encoding also strips any EXIF/metadata the original carried.
+
+Decoding is the dangerous step. A small file can describe an enormous bitmap (a
+"decompression bomb"); fully decoding it can exhaust a worker's CPU/RAM. We
+guard against that twice: the header's declared dimensions are checked before
+any pixels are read, and Pillow's own bomb detector is left armed as a backstop.
 """
 
 from __future__ import annotations
@@ -12,18 +17,28 @@ import io
 
 from PIL import Image, UnidentifiedImageError
 
-from gamatrix.constants import PROFILE_PIC_SIZE
+from gamatrix.constants import PROFILE_PIC_MAX_INPUT_PIXELS, PROFILE_PIC_SIZE
+
+# Arm Pillow's built-in bomb detector at our own threshold: load() raises
+# DecompressionBombError past 2x this, and warns past it, regardless of format.
+Image.MAX_IMAGE_PIXELS = PROFILE_PIC_MAX_INPUT_PIXELS
 
 
 def process_profile_pic(raw: bytes) -> bytes:
     """Validate, resize, and re-encode an uploaded image as a PNG thumbnail.
 
-    Raises ValueError if the bytes aren't a readable image.
+    Raises ValueError if the bytes aren't a readable image or describe a bitmap
+    larger than PROFILE_PIC_MAX_INPUT_PIXELS.
     """
     try:
         opened = Image.open(io.BytesIO(raw))
+        # open() only reads the header, so size is known before any pixels are
+        # decoded. Reject oversized bitmaps here, before the expensive load().
+        width, height = opened.size
+        if width * height > PROFILE_PIC_MAX_INPUT_PIXELS:
+            raise ValueError("That image is too large to process.")
         opened.load()
-    except (UnidentifiedImageError, OSError) as exc:
+    except (UnidentifiedImageError, OSError, Image.DecompressionBombError) as exc:
         raise ValueError("That file isn't a readable image.") from exc
 
     img = opened.convert("RGBA")

--- a/src/gamatrix/images.py
+++ b/src/gamatrix/images.py
@@ -1,0 +1,35 @@
+"""Profile-picture image processing.
+
+User-uploaded images are normalized server-side before they reach S3: decoded
+(which validates that the bytes really are an image), flattened onto a
+transparent canvas, downscaled to a small square-ish thumbnail, and re-encoded
+as PNG. Re-encoding also strips any EXIF/metadata the original carried.
+"""
+
+from __future__ import annotations
+
+import io
+
+from PIL import Image, UnidentifiedImageError
+
+from gamatrix.constants import PROFILE_PIC_SIZE
+
+
+def process_profile_pic(raw: bytes) -> bytes:
+    """Validate, resize, and re-encode an uploaded image as a PNG thumbnail.
+
+    Raises ValueError if the bytes aren't a readable image.
+    """
+    try:
+        opened = Image.open(io.BytesIO(raw))
+        opened.load()
+    except (UnidentifiedImageError, OSError) as exc:
+        raise ValueError("That file isn't a readable image.") from exc
+
+    img = opened.convert("RGBA")
+    # thumbnail() preserves aspect ratio, fitting within the bounding box.
+    img.thumbnail((PROFILE_PIC_SIZE, PROFILE_PIC_SIZE))
+
+    out = io.BytesIO()
+    img.save(out, format="PNG")
+    return out.getvalue()

--- a/src/gamatrix/preferences.py
+++ b/src/gamatrix/preferences.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import time
 
-from fastapi import APIRouter, Depends, File, Request, UploadFile
+from fastapi import APIRouter, Depends, Request
 from fastapi.responses import HTMLResponse, JSONResponse, Response
 
 from gamatrix.auth.dependencies import current_user, current_user_api, get_repo
@@ -13,7 +13,6 @@ from gamatrix.games.preferences import merge_preferences
 from gamatrix.helpers import pic_url
 from gamatrix.images import process_profile_pic
 from gamatrix.storage.dynamo import Repository
-from gamatrix.storage.s3 import get_s3
 from gamatrix.templating import templates
 
 router = APIRouter(tags=["preferences"])
@@ -98,15 +97,33 @@ async def save_profile(
     return JSONResponse({"username": name})
 
 
+async def _read_body_capped(request: Request, limit: int) -> bytes | None:
+    """Read the raw request body in chunks, aborting as soon as it crosses
+    `limit`. Returns None if oversized, so an attacker can't force the whole
+    body to be buffered to memory/disk before the size is checked."""
+    chunks: list[bytes] = []
+    total = 0
+    async for chunk in request.stream():
+        total += len(chunk)
+        if total > limit:
+            return None
+        chunks.append(chunk)
+    return b"".join(chunks)
+
+
 @router.post("/profile/pic")
 async def upload_profile_pic(
-    file: UploadFile = File(...),
+    request: Request,
     user: dict = Depends(current_user_api),
     repo: Repository = Depends(get_repo),
 ):
-    """Accept an image upload, resize it, and store it as the user's pic."""
-    raw = await file.read()
-    if len(raw) > PROFILE_PIC_MAX_UPLOAD_SIZE:
+    """Accept a raw image body, resize it, and store it as the user's pic.
+
+    The image is sent as the raw request body (not multipart) so it can be read
+    with an early size cap instead of being buffered in full first.
+    """
+    raw = await _read_body_capped(request, PROFILE_PIC_MAX_UPLOAD_SIZE)
+    if raw is None:
         mb = PROFILE_PIC_MAX_UPLOAD_SIZE // (1024 * 1024)
         return JSONResponse(
             {"error": f"Image must be {mb} MB or smaller."}, status_code=400
@@ -116,11 +133,11 @@ async def upload_profile_pic(
     except ValueError as exc:
         return JSONResponse({"error": str(exc)}, status_code=400)
 
-    key = f"profile_img/{user['email'].lower()}.png"
-    get_s3().put_bytes(key, png, "image/png")
+    user_id = str(user["user_id"])
+    repo.put_profile_pic(user_id, png)
     updated = int(time.time())
-    repo.update_user(user["email"], {"pic_key": key, "pic_updated": updated})
-    url = pic_url({**user, "pic_key": key, "pic_updated": updated})
+    repo.update_user(user["email"], {"pic_updated": updated})
+    url = pic_url({**user, "pic_updated": updated})
     return JSONResponse({"pic_url": url})
 
 
@@ -130,17 +147,18 @@ def serve_profile_pic(
     _: dict = Depends(current_user),
     repo: Repository = Depends(get_repo),
 ):
-    """Stream a user-uploaded profile pic from S3 (gated to logged-in users)."""
-    target = repo.get_user_by_user_id(user_id)
-    key = target.get("pic_key") if target else None
-    if not key:
-        return Response(status_code=404)
-    data = get_s3().get_bytes(key)
+    """Serve a user-uploaded profile pic (gated to logged-in users).
+
+    A single keyed read from the profile_pics table — no full-table scan.
+    """
+    data = repo.get_profile_pic(user_id)
     if data is None:
         return Response(status_code=404)
-    # Safe to cache hard: the URL carries a ?v= cache-buster on each update.
+    # private (not public): the route is auth-gated, so shared proxy/CDN
+    # caches must not hold it. The ?v= cache-buster keeps the browser cache
+    # fresh across updates.
     return Response(
         content=data,
         media_type="image/png",
-        headers={"Cache-Control": "public, max-age=86400"},
+        headers={"Cache-Control": "private, max-age=86400"},
     )

--- a/src/gamatrix/preferences.py
+++ b/src/gamatrix/preferences.py
@@ -2,13 +2,18 @@
 
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, Request
+import time
+
+from fastapi import APIRouter, Depends, File, Request, UploadFile
 from fastapi.responses import HTMLResponse, JSONResponse, Response
 
 from gamatrix.auth.dependencies import current_user, current_user_api, get_repo
-from gamatrix.constants import DISPLAY_NAME_MAX_LENGTH
+from gamatrix.constants import DISPLAY_NAME_MAX_LENGTH, PROFILE_PIC_MAX_UPLOAD_SIZE
 from gamatrix.games.preferences import merge_preferences
+from gamatrix.helpers import pic_url
+from gamatrix.images import process_profile_pic
 from gamatrix.storage.dynamo import Repository
+from gamatrix.storage.s3 import get_s3
 from gamatrix.templating import templates
 
 router = APIRouter(tags=["preferences"])
@@ -91,3 +96,51 @@ async def save_profile(
         return JSONResponse({"error": str(exc)}, status_code=400)
     repo.update_user(user["email"], {"username": name})
     return JSONResponse({"username": name})
+
+
+@router.post("/profile/pic")
+async def upload_profile_pic(
+    file: UploadFile = File(...),
+    user: dict = Depends(current_user_api),
+    repo: Repository = Depends(get_repo),
+):
+    """Accept an image upload, resize it, and store it as the user's pic."""
+    raw = await file.read()
+    if len(raw) > PROFILE_PIC_MAX_UPLOAD_SIZE:
+        mb = PROFILE_PIC_MAX_UPLOAD_SIZE // (1024 * 1024)
+        return JSONResponse(
+            {"error": f"Image must be {mb} MB or smaller."}, status_code=400
+        )
+    try:
+        png = process_profile_pic(raw)
+    except ValueError as exc:
+        return JSONResponse({"error": str(exc)}, status_code=400)
+
+    key = f"profile_img/{user['email'].lower()}.png"
+    get_s3().put_bytes(key, png, "image/png")
+    updated = int(time.time())
+    repo.update_user(user["email"], {"pic_key": key, "pic_updated": updated})
+    url = pic_url({**user, "pic_key": key, "pic_updated": updated})
+    return JSONResponse({"pic_url": url})
+
+
+@router.get("/profile_img/{user_id}")
+def serve_profile_pic(
+    user_id: str,
+    _: dict = Depends(current_user),
+    repo: Repository = Depends(get_repo),
+):
+    """Stream a user-uploaded profile pic from S3 (gated to logged-in users)."""
+    target = repo.get_user_by_user_id(user_id)
+    key = target.get("pic_key") if target else None
+    if not key:
+        return Response(status_code=404)
+    data = get_s3().get_bytes(key)
+    if data is None:
+        return Response(status_code=404)
+    # Safe to cache hard: the URL carries a ?v= cache-buster on each update.
+    return Response(
+        content=data,
+        media_type="image/png",
+        headers={"Cache-Control": "public, max-age=86400"},
+    )

--- a/src/gamatrix/storage/dynamo.py
+++ b/src/gamatrix/storage/dynamo.py
@@ -265,6 +265,25 @@ class Repository:
         return len(rows)
 
     # ------------------------------------------------------------------
+    # profile_pics  (PK user_id -> processed PNG bytes)
+    # ------------------------------------------------------------------
+    def put_profile_pic(self, user_id: str, data: bytes) -> None:
+        self._table(self.settings.profile_pics_table).put_item(
+            Item={"user_id": str(user_id), "data": data}
+        )
+
+    def get_profile_pic(self, user_id: str) -> bytes | None:
+        """Return a user's stored pic bytes via a single keyed read, or None."""
+        resp = self._table(self.settings.profile_pics_table).get_item(
+            Key={"user_id": str(user_id)}
+        )
+        item = resp.get("Item")
+        if not item or "data" not in item:
+            return None
+        # boto3 hands binary attributes back wrapped in a Binary type.
+        return bytes(item["data"])
+
+    # ------------------------------------------------------------------
     # config  (PK key -> value)  used locally for hidden/single-player lists
     # ------------------------------------------------------------------
     def get_config(self, key: str, default: Any = None) -> Any:

--- a/src/gamatrix/storage/s3.py
+++ b/src/gamatrix/storage/s3.py
@@ -45,23 +45,6 @@ class S3Storage:
     def delete(self, key: str) -> None:
         self._client.delete_object(Bucket=self.settings.upload_bucket, Key=key)
 
-    def put_bytes(self, key: str, data: bytes, content_type: str) -> None:
-        """Upload in-memory bytes (e.g. a processed profile pic)."""
-        self._client.put_object(
-            Bucket=self.settings.upload_bucket,
-            Key=key,
-            Body=data,
-            ContentType=content_type,
-        )
-
-    def get_bytes(self, key: str) -> bytes | None:
-        """Return an object's bytes, or None if it doesn't exist."""
-        try:
-            resp = self._client.get_object(Bucket=self.settings.upload_bucket, Key=key)
-        except self._client.exceptions.NoSuchKey:
-            return None
-        return resp["Body"].read()
-
 
 _s3: S3Storage | None = None
 

--- a/src/gamatrix/storage/s3.py
+++ b/src/gamatrix/storage/s3.py
@@ -45,6 +45,23 @@ class S3Storage:
     def delete(self, key: str) -> None:
         self._client.delete_object(Bucket=self.settings.upload_bucket, Key=key)
 
+    def put_bytes(self, key: str, data: bytes, content_type: str) -> None:
+        """Upload in-memory bytes (e.g. a processed profile pic)."""
+        self._client.put_object(
+            Bucket=self.settings.upload_bucket,
+            Key=key,
+            Body=data,
+            ContentType=content_type,
+        )
+
+    def get_bytes(self, key: str) -> bytes | None:
+        """Return an object's bytes, or None if it doesn't exist."""
+        try:
+            resp = self._client.get_object(Bucket=self.settings.upload_bucket, Key=key)
+        except self._client.exceptions.NoSuchKey:
+            return None
+        return resp["Body"].read()
+
 
 _s3: S3Storage | None = None
 

--- a/src/gamatrix/templates/games.html.jinja
+++ b/src/gamatrix/templates/games.html.jinja
@@ -30,7 +30,8 @@
         <label title="DB updated: {{ u.get('db_updated_at', 'never') }}">
             <input type="checkbox" name="user" value="{{ uid }}"
                    {% if uid in opts.selected_user_ids %}checked{% endif %}>
-            {% if u.pic %}<img src="/static/profile_img/{{ u.pic }}" width="18" height="18">{% endif %}
+            {% set pu = pic_url(u) %}
+            {% if pu %}<img src="{{ pu }}" width="18" height="18">{% endif %}
             {{ u.username }}
         </label>
         {% endfor %}

--- a/src/gamatrix/templates/games_table.html.jinja
+++ b/src/gamatrix/templates/games_table.html.jinja
@@ -21,8 +21,9 @@
                 {% for uid in selected %}
                 {% if uid in users %}
                 <th title="{{ users[uid].username }}">
-                    {% if users[uid].pic %}
-                    <img src="/static/profile_img/{{ users[uid].pic }}" width="20" height="20">
+                    {% set pu = pic_url(users[uid]) %}
+                    {% if pu %}
+                    <img src="{{ pu }}" width="20" height="20">
                     {% else %}{{ users[uid].username }}{% endif %}
                 </th>
                 {% endif %}
@@ -59,8 +60,9 @@
                 {% if uid in users %}
                 <td class="{{ 'owned' if uid in game.owners else 'unowned' }}" style="text-align:center;">
                     {% if uid in game.installed %}
-                        {% if users[uid].pic %}
-                        <img src="/static/profile_img/{{ users[uid].pic }}" width="18" height="18" title="installed">
+                        {% set pu = pic_url(users[uid]) %}
+                        {% if pu %}
+                        <img src="{{ pu }}" width="18" height="18" title="installed">
                         {% else %}✓{% endif %}
                     {% endif %}
                 </td>
@@ -74,10 +76,11 @@
                 {% if selected|length == game.installed|length and game.installed %}
                     <b>✓</b>
                 {% else %}
-                    {% for uid in game.installed %}
-                    {% if uid in users and users[uid].pic %}
-                    <img src="/static/profile_img/{{ users[uid].pic }}" width="18" height="18" title="{{ users[uid].username }}">
-                    {% elif uid in users %}{{ users[uid].username }}{% endif %}
+                    {% for uid in game.installed if uid in users %}
+                    {% set pu = pic_url(users[uid]) %}
+                    {% if pu %}
+                    <img src="{{ pu }}" width="18" height="18" title="{{ users[uid].username }}">
+                    {% else %}{{ users[uid].username }}{% endif %}
                     {% endfor %}
                 {% endif %}
             </td>

--- a/src/gamatrix/templates/preferences.html.jinja
+++ b/src/gamatrix/templates/preferences.html.jinja
@@ -21,20 +21,47 @@
     </fieldset>
 </form>
 
-<form id="profilepic" enctype="multipart/form-data" class="filters"
-      hx-post="/profile/pic" hx-encoding="multipart/form-data" hx-swap="none"
-      hx-on::after-request="if(event.detail.successful){const r=JSON.parse(event.detail.xhr.responseText);if(r.pic_url){this.querySelector('.pic-preview').src=r.pic_url}this.querySelector('.saved').style.display='inline';this.querySelector('.error').style.display='none'}else{const e=this.querySelector('.error');e.textContent=JSON.parse(event.detail.xhr.responseText).error;e.style.display='inline';this.querySelector('.saved').style.display='none'}">
+<div id="profilepic" class="filters">
     <fieldset class="filter-group">
         <legend>Profile picture</legend>
         {% set pu = pic_url(user) %}
         <img class="pic-preview" width="48" height="48"
              src="{{ pu or '/static/profile_img/question_block.jpg' }}">
-        <input type="file" name="file" accept="image/*" required>
-        <button type="submit">Upload</button>
+        <input type="file" id="pic-file" accept="image/*">
+        <button type="button" onclick="uploadProfilePic()">Upload</button>
         <span class="saved muted" style="display:none;">Saved ✓</span>
         <span class="error" style="display:none;color:#c00;"></span>
     </fieldset>
-</form>
+</div>
+<script>
+// Send the file as the raw request body so the server can size-cap it as it
+// streams, rather than receiving a fully-buffered multipart upload.
+async function uploadProfilePic() {
+    const box = document.getElementById('profilepic');
+    const saved = box.querySelector('.saved');
+    const error = box.querySelector('.error');
+    const file = document.getElementById('pic-file').files[0];
+    if (!file) { return; }
+    saved.style.display = 'none';
+    error.style.display = 'none';
+    let data = {};
+    try {
+        const resp = await fetch('/profile/pic', {
+            method: 'POST',
+            headers: {'Content-Type': file.type || 'application/octet-stream'},
+            body: file,
+        });
+        data = await resp.json().catch(() => ({}));
+        if (!resp.ok) { throw new Error(data.error || 'Upload failed.'); }
+    } catch (e) {
+        error.textContent = e.message || 'Upload failed.';
+        error.style.display = 'inline';
+        return;
+    }
+    if (data.pic_url) { box.querySelector('.pic-preview').src = data.pic_url; }
+    saved.style.display = 'inline';
+}
+</script>
 
 <form id="filters" method="post" action="/preferences" class="filters"
       hx-post="/preferences" hx-swap="none"

--- a/src/gamatrix/templates/preferences.html.jinja
+++ b/src/gamatrix/templates/preferences.html.jinja
@@ -21,6 +21,21 @@
     </fieldset>
 </form>
 
+<form id="profilepic" enctype="multipart/form-data" class="filters"
+      hx-post="/profile/pic" hx-encoding="multipart/form-data" hx-swap="none"
+      hx-on::after-request="if(event.detail.successful){const r=JSON.parse(event.detail.xhr.responseText);if(r.pic_url){this.querySelector('.pic-preview').src=r.pic_url}this.querySelector('.saved').style.display='inline';this.querySelector('.error').style.display='none'}else{const e=this.querySelector('.error');e.textContent=JSON.parse(event.detail.xhr.responseText).error;e.style.display='inline';this.querySelector('.saved').style.display='none'}">
+    <fieldset class="filter-group">
+        <legend>Profile picture</legend>
+        {% set pu = pic_url(user) %}
+        <img class="pic-preview" width="48" height="48"
+             src="{{ pu or '/static/profile_img/question_block.jpg' }}">
+        <input type="file" name="file" accept="image/*" required>
+        <button type="submit">Upload</button>
+        <span class="saved muted" style="display:none;">Saved ✓</span>
+        <span class="error" style="display:none;color:#c00;"></span>
+    </fieldset>
+</form>
+
 <form id="filters" method="post" action="/preferences" class="filters"
       hx-post="/preferences" hx-swap="none"
       hx-on::after-request="this.querySelector('.saved').style.display='inline'">

--- a/src/gamatrix/templating.py
+++ b/src/gamatrix/templating.py
@@ -8,9 +8,11 @@ from fastapi.templating import Jinja2Templates
 
 from gamatrix import __version__
 from gamatrix.constants import PLATFORMS
+from gamatrix.helpers import pic_url
 
 TEMPLATES_DIR = Path(__file__).parent / "templates"
 
 templates = Jinja2Templates(directory=str(TEMPLATES_DIR))
 templates.env.globals["version"] = __version__
 templates.env.globals["platforms"] = list(PLATFORMS)
+templates.env.globals["pic_url"] = pic_url

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -59,6 +59,7 @@ def _create_tables(settings: Settings) -> None:
     for name, pk in [
         (settings.jobs_table, "job_id"),
         (settings.metadata_table, "slug"),
+        (settings.profile_pics_table, "user_id"),
         (settings.config_table, "key"),
     ]:
         ddb.create_table(

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -34,3 +34,12 @@ def test_process_leaves_small_image_dimensions_alone():
 def test_process_rejects_non_image():
     with pytest.raises(ValueError, match="readable image"):
         process_profile_pic(b"this is not an image")
+
+
+def test_process_rejects_oversized_bitmap(monkeypatch):
+    # Lower the pixel cap so a small test image trips the decompression-bomb
+    # guard cheaply. The guard must reject on declared dimensions, before the
+    # image is fully decoded.
+    monkeypatch.setattr("gamatrix.images.PROFILE_PIC_MAX_INPUT_PIXELS", 100)
+    with pytest.raises(ValueError, match="too large"):
+        process_profile_pic(_png_bytes((50, 50)))  # 2500 px > 100

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -1,0 +1,36 @@
+"""Tests for profile-pic image processing."""
+
+from __future__ import annotations
+
+import io
+
+import pytest
+from PIL import Image
+
+from gamatrix.constants import PROFILE_PIC_SIZE
+from gamatrix.images import process_profile_pic
+
+
+def _png_bytes(size: tuple[int, int], color: str = "red") -> bytes:
+    buf = io.BytesIO()
+    Image.new("RGB", size, color).save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def test_process_resizes_large_image_within_box():
+    out = process_profile_pic(_png_bytes((1000, 500)))
+    img = Image.open(io.BytesIO(out))
+    assert img.format == "PNG"
+    assert max(img.size) == PROFILE_PIC_SIZE  # longest side fits the box
+    assert img.size == (PROFILE_PIC_SIZE, PROFILE_PIC_SIZE // 2)  # aspect kept
+
+
+def test_process_leaves_small_image_dimensions_alone():
+    out = process_profile_pic(_png_bytes((32, 32)))
+    img = Image.open(io.BytesIO(out))
+    assert img.size == (32, 32)
+
+
+def test_process_rejects_non_image():
+    with pytest.raises(ValueError, match="readable image"):
+        process_profile_pic(b"this is not an image")

--- a/tests/test_preferences.py
+++ b/tests/test_preferences.py
@@ -6,6 +6,7 @@ import pytest
 
 from gamatrix import preferences
 from gamatrix.constants import DISPLAY_NAME_MAX_LENGTH
+from gamatrix.helpers import pic_url
 
 
 def test_clean_display_name_trims_and_collapses_whitespace():
@@ -27,3 +28,17 @@ def test_save_profile_persists_username(repo):
     name = preferences.clean_display_name(" New ")
     repo.update_user("user@x.com", {"username": name})
     assert repo.get_user("user@x.com")["username"] == "New"
+
+
+def test_pic_url_prefers_uploaded_pic_with_cache_buster():
+    user = {"user_id": "7", "pic_key": "profile_img/u@x.com.png", "pic_updated": 123}
+    assert pic_url(user) == "/profile_img/7?v=123"
+
+
+def test_pic_url_falls_back_to_static_seeded_pic():
+    user = {"user_id": "7", "pic": "Kane.png"}
+    assert pic_url(user) == "/static/profile_img/Kane.png"
+
+
+def test_pic_url_none_when_no_pic():
+    assert pic_url({"user_id": "7"}) is None

--- a/tests/test_preferences.py
+++ b/tests/test_preferences.py
@@ -31,8 +31,17 @@ def test_save_profile_persists_username(repo):
 
 
 def test_pic_url_prefers_uploaded_pic_with_cache_buster():
-    user = {"user_id": "7", "pic_key": "profile_img/u@x.com.png", "pic_updated": 123}
+    user = {"user_id": "7", "pic_updated": 123}
     assert pic_url(user) == "/profile_img/7?v=123"
+
+
+def test_profile_pic_round_trips_through_dynamo(repo):
+    repo.put_profile_pic("7", b"\x89PNG-bytes")
+    assert repo.get_profile_pic("7") == b"\x89PNG-bytes"
+
+
+def test_get_profile_pic_missing_returns_none(repo):
+    assert repo.get_profile_pic("nobody") is None
 
 
 def test_pic_url_falls_back_to_static_seeded_pic():

--- a/uv.lock
+++ b/uv.lock
@@ -684,6 +684,7 @@ dependencies = [
     { name = "itsdangerous" },
     { name = "jinja2" },
     { name = "mangum" },
+    { name = "pillow" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "python-jose", extra = ["cryptography"] },
@@ -730,6 +731,7 @@ requires-dist = [
     { name = "mangum", specifier = "==0.19.0" },
     { name = "moto", extras = ["dynamodb", "s3", "ses", "sqs"], marker = "extra == 'dev'" },
     { name = "mypy", marker = "extra == 'dev'" },
+    { name = "pillow", specifier = "==11.1.0" },
     { name = "pydantic", specifier = "==2.10.4" },
     { name = "pydantic-settings", specifier = "==2.7.1" },
     { name = "pytest", marker = "extra == 'dev'" },
@@ -1159,6 +1161,44 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
+]
+
+[[package]]
+name = "pillow"
+version = "11.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/af/c097e544e7bd278333db77933e535098c259609c4eb3b85381109602fb5b/pillow-11.1.0.tar.gz", hash = "sha256:368da70808b36d73b4b390a8ffac11069f8a5c85f29eff1f1b01bcf3ef5b2a20", size = 46742715, upload-time = "2025-01-02T08:13:58.407Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/95/20/9ce6ed62c91c073fcaa23d216e68289e19d95fb8188b9fb7a63d36771db8/pillow-11.1.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2062ffb1d36544d42fcaa277b069c88b01bb7298f4efa06731a7fd6cc290b81a", size = 3226818, upload-time = "2025-01-02T08:11:22.518Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/d8/f6004d98579a2596c098d1e30d10b248798cceff82d2b77aa914875bfea1/pillow-11.1.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:a85b653980faad27e88b141348707ceeef8a1186f75ecc600c395dcac19f385b", size = 3101662, upload-time = "2025-01-02T08:11:25.19Z" },
+    { url = "https://files.pythonhosted.org/packages/08/d9/892e705f90051c7a2574d9f24579c9e100c828700d78a63239676f960b74/pillow-11.1.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9409c080586d1f683df3f184f20e36fb647f2e0bc3988094d4fd8c9f4eb1b3b3", size = 4329317, upload-time = "2025-01-02T08:11:30.371Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/aa/7f29711f26680eab0bcd3ecdd6d23ed6bce180d82e3f6380fb7ae35fcf3b/pillow-11.1.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7fdadc077553621911f27ce206ffcbec7d3f8d7b50e0da39f10997e8e2bb7f6a", size = 4412999, upload-time = "2025-01-02T08:11:33.499Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/c4/8f0fe3b9e0f7196f6d0bbb151f9fba323d72a41da068610c4c960b16632a/pillow-11.1.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:93a18841d09bcdd774dcdc308e4537e1f867b3dec059c131fde0327899734aa1", size = 4368819, upload-time = "2025-01-02T08:11:37.304Z" },
+    { url = "https://files.pythonhosted.org/packages/38/0d/84200ed6a871ce386ddc82904bfadc0c6b28b0c0ec78176871a4679e40b3/pillow-11.1.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:9aa9aeddeed452b2f616ff5507459e7bab436916ccb10961c4a382cd3e03f47f", size = 4496081, upload-time = "2025-01-02T08:11:39.598Z" },
+    { url = "https://files.pythonhosted.org/packages/84/9c/9bcd66f714d7e25b64118e3952d52841a4babc6d97b6d28e2261c52045d4/pillow-11.1.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3cdcdb0b896e981678eee140d882b70092dac83ac1cdf6b3a60e2216a73f2b91", size = 4296513, upload-time = "2025-01-02T08:11:43.083Z" },
+    { url = "https://files.pythonhosted.org/packages/db/61/ada2a226e22da011b45f7104c95ebda1b63dcbb0c378ad0f7c2a710f8fd2/pillow-11.1.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:36ba10b9cb413e7c7dfa3e189aba252deee0602c86c309799da5a74009ac7a1c", size = 4431298, upload-time = "2025-01-02T08:11:46.626Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/c4/fc6e86750523f367923522014b821c11ebc5ad402e659d8c9d09b3c9d70c/pillow-11.1.0-cp312-cp312-win32.whl", hash = "sha256:cfd5cd998c2e36a862d0e27b2df63237e67273f2fc78f47445b14e73a810e7e6", size = 2291630, upload-time = "2025-01-02T08:11:49.401Z" },
+    { url = "https://files.pythonhosted.org/packages/08/5c/2104299949b9d504baf3f4d35f73dbd14ef31bbd1ddc2c1b66a5b7dfda44/pillow-11.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:a697cd8ba0383bba3d2d3ada02b34ed268cb548b369943cd349007730c92bddf", size = 2626369, upload-time = "2025-01-02T08:11:52.02Z" },
+    { url = "https://files.pythonhosted.org/packages/37/f3/9b18362206b244167c958984b57c7f70a0289bfb59a530dd8af5f699b910/pillow-11.1.0-cp312-cp312-win_arm64.whl", hash = "sha256:4dd43a78897793f60766563969442020e90eb7847463eca901e41ba186a7d4a5", size = 2375240, upload-time = "2025-01-02T08:11:56.193Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/31/9ca79cafdce364fd5c980cd3416c20ce1bebd235b470d262f9d24d810184/pillow-11.1.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:ae98e14432d458fc3de11a77ccb3ae65ddce70f730e7c76140653048c71bfcbc", size = 3226640, upload-time = "2025-01-02T08:11:58.329Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/0f/ff07ad45a1f172a497aa393b13a9d81a32e1477ef0e869d030e3c1532521/pillow-11.1.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:cc1331b6d5a6e144aeb5e626f4375f5b7ae9934ba620c0ac6b3e43d5e683a0f0", size = 3101437, upload-time = "2025-01-02T08:12:01.797Z" },
+    { url = "https://files.pythonhosted.org/packages/08/2f/9906fca87a68d29ec4530be1f893149e0cb64a86d1f9f70a7cfcdfe8ae44/pillow-11.1.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:758e9d4ef15d3560214cddbc97b8ef3ef86ce04d62ddac17ad39ba87e89bd3b1", size = 4326605, upload-time = "2025-01-02T08:12:05.224Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/0f/f3547ee15b145bc5c8b336401b2d4c9d9da67da9dcb572d7c0d4103d2c69/pillow-11.1.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b523466b1a31d0dcef7c5be1f20b942919b62fd6e9a9be199d035509cbefc0ec", size = 4411173, upload-time = "2025-01-02T08:12:08.281Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/df/bf8176aa5db515c5de584c5e00df9bab0713548fd780c82a86cba2c2fedb/pillow-11.1.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:9044b5e4f7083f209c4e35aa5dd54b1dd5b112b108648f5c902ad586d4f945c5", size = 4369145, upload-time = "2025-01-02T08:12:11.411Z" },
+    { url = "https://files.pythonhosted.org/packages/de/7c/7433122d1cfadc740f577cb55526fdc39129a648ac65ce64db2eb7209277/pillow-11.1.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:3764d53e09cdedd91bee65c2527815d315c6b90d7b8b79759cc48d7bf5d4f114", size = 4496340, upload-time = "2025-01-02T08:12:15.29Z" },
+    { url = "https://files.pythonhosted.org/packages/25/46/dd94b93ca6bd555588835f2504bd90c00d5438fe131cf01cfa0c5131a19d/pillow-11.1.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:31eba6bbdd27dde97b0174ddf0297d7a9c3a507a8a1480e1e60ef914fe23d352", size = 4296906, upload-time = "2025-01-02T08:12:17.485Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/28/2f9d32014dfc7753e586db9add35b8a41b7a3b46540e965cb6d6bc607bd2/pillow-11.1.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:b5d658fbd9f0d6eea113aea286b21d3cd4d3fd978157cbf2447a6035916506d3", size = 4431759, upload-time = "2025-01-02T08:12:20.382Z" },
+    { url = "https://files.pythonhosted.org/packages/33/48/19c2cbe7403870fbe8b7737d19eb013f46299cdfe4501573367f6396c775/pillow-11.1.0-cp313-cp313-win32.whl", hash = "sha256:f86d3a7a9af5d826744fabf4afd15b9dfef44fe69a98541f666f66fbb8d3fef9", size = 2291657, upload-time = "2025-01-02T08:12:23.922Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/ad/285c556747d34c399f332ba7c1a595ba245796ef3e22eae190f5364bb62b/pillow-11.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:593c5fd6be85da83656b93ffcccc2312d2d149d251e98588b14fbc288fd8909c", size = 2626304, upload-time = "2025-01-02T08:12:28.069Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/7b/ef35a71163bf36db06e9c8729608f78dedf032fc8313d19bd4be5c2588f3/pillow-11.1.0-cp313-cp313-win_arm64.whl", hash = "sha256:11633d58b6ee5733bde153a8dafd25e505ea3d32e261accd388827ee987baf65", size = 2375117, upload-time = "2025-01-02T08:12:30.064Z" },
+    { url = "https://files.pythonhosted.org/packages/79/30/77f54228401e84d6791354888549b45824ab0ffde659bafa67956303a09f/pillow-11.1.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:70ca5ef3b3b1c4a0812b5c63c57c23b63e53bc38e758b37a951e5bc466449861", size = 3230060, upload-time = "2025-01-02T08:12:32.362Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/b1/56723b74b07dd64c1010fee011951ea9c35a43d8020acd03111f14298225/pillow-11.1.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:8000376f139d4d38d6851eb149b321a52bb8893a88dae8ee7d95840431977081", size = 3106192, upload-time = "2025-01-02T08:12:34.361Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/cd/7bf7180e08f80a4dcc6b4c3a0aa9e0b0ae57168562726a05dc8aa8fa66b0/pillow-11.1.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9ee85f0696a17dd28fbcfceb59f9510aa71934b483d1f5601d1030c3c8304f3c", size = 4446805, upload-time = "2025-01-02T08:12:36.99Z" },
+    { url = "https://files.pythonhosted.org/packages/97/42/87c856ea30c8ed97e8efbe672b58c8304dee0573f8c7cab62ae9e31db6ae/pillow-11.1.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:dd0e081319328928531df7a0e63621caf67652c8464303fd102141b785ef9547", size = 4530623, upload-time = "2025-01-02T08:12:41.912Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/41/026879e90c84a88e33fb00cc6bd915ac2743c67e87a18f80270dfe3c2041/pillow-11.1.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:e63e4e5081de46517099dc30abe418122f54531a6ae2ebc8680bcd7096860eab", size = 4465191, upload-time = "2025-01-02T08:12:45.186Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/fb/a7960e838bc5df57a2ce23183bfd2290d97c33028b96bde332a9057834d3/pillow-11.1.0-cp313-cp313t-win32.whl", hash = "sha256:dda60aa465b861324e65a78c9f5cf0f4bc713e4309f83bc387be158b077963d9", size = 2295494, upload-time = "2025-01-02T08:12:47.098Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/6c/6ec83ee2f6f0fda8d4cf89045c6be4b0373ebfc363ba8538f8c999f63fcd/pillow-11.1.0-cp313-cp313t-win_amd64.whl", hash = "sha256:ad5db5781c774ab9a9b2c4302bbf0c1014960a0a7be63278d13ae6fdf88126fe", size = 2631595, upload-time = "2025-01-02T08:12:50.47Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/6c/41c21c6c8af92b9fea313aa47c75de49e2f9a467964ee33eb0135d47eb64/pillow-11.1.0-cp313-cp313t-win_arm64.whl", hash = "sha256:67cd427c68926108778a9005f2a04adbd5e67c442ed21d95389fe1d595458756", size = 2377651, upload-time = "2025-01-02T08:12:53.356Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Completes #133. **Stacked on #149** (display name) — base is `user-display-name`, so this diff shows only the profile-pic changes. Merge #149 first, or rebase this onto master after it lands.

## What

Adds a **Profile picture** uploader to the preferences page (with a live preview), so users can replace the seeded static avatars with their own image.

## Architecture

- **Storage:** uploaded pics are stored in a dedicated `profile_pics` DynamoDB table keyed by `user_id` (processed 128px PNGs, ~tens of KB, comfortably under the 400KB item limit). Serving is a single keyed `get_item` — no full-table scan. Adds one table (CDK + `init_local` + a `Settings` property); no S3 involvement for this feature.
- **Upload path:** the image is sent as the **raw request body** (not multipart) and read from `request.stream()` with an early size cap, so an oversized body is aborted before it buffers to memory/disk. It's then processed with Pillow — decoded (validates it's really an image), bounds-checked against a max pixel count *before* full decode (decompression-bomb guard), resized to a ≤128px PNG, and re-encoded (strips EXIF).
- **Serving:** `GET /profile_img/{user_id}` streams the pic from DynamoDB, gated to logged-in users, with `Cache-Control: private` (the route is auth-gated). URLs carry a `?v=` cache-buster derived from the last update, so the browser cache stays fresh.
- **Resolution:** a `pic_url(user)` helper (registered as a Jinja global) returns the uploaded pic via the route (keyed off `pic_updated`), else the seeded static file, else `None`. The games/preferences templates use it instead of hardcoding `/static/profile_img/...`.

New user field: `pic_updated` (epoch; doubles as the cache-buster and the "has an upload" flag). Adds one dependency: `pillow`.

## Tests

- `tests/test_images.py` — resize/aspect/format, non-image rejection, decompression-bomb rejection.
- `tests/test_preferences.py` — `pic_url` resolution, DynamoDB pic round-trip, missing-pic None.
- Verified end-to-end against moto: pre-upload 404 → non-image 400 → oversized 400 (early abort) → upload 200 (cache-busted URL) → serve returns a 128px `image/png` with `Cache-Control: private`.

`just check` (black + flake8 + mypy + pytest, 56 tests) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
