### PR TITLE
Resolve PR labels from commit subject in version workflow

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -33,8 +33,41 @@ jobs:
           set -euo pipefail
 
           # --- Determine the bump level from the merged PR's labels ----------
-          labels="$(gh api "repos/$REPO/commits/$SHA/pulls" \
-            --jq '.[].labels[].name' 2>/dev/null || true)"
+          # Resolve the merged PR number from the commit subject first. The
+          # commits/{sha}/pulls API is eventually consistent and frequently
+          # returns nothing in the seconds after the push event fires, so we
+          # rely on it only as a fallback (with retries) when the subject has
+          # no PR reference (e.g. a rebase merge or a direct push).
+          subject="$(git log -1 --format=%s "$SHA")"
+          echo "Merge commit subject: $subject"
+
+          pr=""
+          # Squash merge: GitHub appends "(#N)" at the very end. Anchor on the
+          # trailing reference so an issue ref earlier in the title (e.g.
+          # "... (#131) (#143)") doesn't get picked up instead of the PR.
+          if [[ "$subject" =~ \(#([0-9]+)\)[[:space:]]*$ ]]; then
+            pr="${BASH_REMATCH[1]}"
+          # Merge commit: "Merge pull request #N from ...".
+          elif [[ "$subject" =~ ^Merge\ pull\ request\ \#([0-9]+) ]]; then
+            pr="${BASH_REMATCH[1]}"
+          fi
+
+          labels=""
+          if [[ -n "$pr" ]]; then
+            echo "Resolved PR #$pr from commit subject"
+            labels="$(gh api "repos/$REPO/pulls/$pr" \
+              --jq '.labels[].name' 2>/dev/null || true)"
+          else
+            echo "No PR number in subject; falling back to commit->PR API"
+            for attempt in 1 2 3 4 5; do
+              labels="$(gh api "repos/$REPO/commits/$SHA/pulls" \
+                --jq '.[].labels[].name' 2>/dev/null || true)"
+              [[ -n "$labels" ]] && break
+              echo "No labels yet (attempt $attempt/5); retrying in 5s..."
+              sleep 5
+            done
+          fi
+
           echo "PR labels for $SHA:"
           echo "${labels:-<none>}"
 


### PR DESCRIPTION
## Problem

The `Version` workflow computes the release bump from the merged PR's labels (`new minor version` / `new major version`). It found them via `gh api repos/$REPO/commits/$SHA/pulls`, but that **commit→PR association is eventually consistent** — in the seconds after the `push` event fires it frequently returns nothing. So the label was intermittently missed and the release fell back to a patch bump.

Most recently this hit **#150** (labeled `new minor version`): [the run](https://github.com/eniklas/gamatrix/actions/runs/27117363915/job/80026868155) didn't find the label.

## Fix

Resolve the PR number from the merge commit subject, which is present deterministically at push time, and read labels from a direct `pulls/{N}` lookup:

- **Squash merges** end with GitHub's appended `(#N)`. The regex anchors on the *trailing* reference, so an issue ref earlier in the title (e.g. `...counts (#131) (#143)`) isn't mistaken for the PR number.
- **Merge commits** start with `Merge pull request #N`.
- If neither matches (rebase merge, direct push), it falls back to the old commit→PR API, now wrapped in a **retry loop** to ride out the indexing delay.

Verified the parsing against representative subjects, including the multi-`#` case (`(#131) (#143)` → resolves to `143`, the PR) and the no-PR case (→ falls back to the API).

🤖 Generated with [Claude Code](https://claude.com/claude-code)