### PR TITLE
Guard `just deploy` against a missing/stale deploy config

### DIFF
--- a/justfile
+++ b/justfile
@@ -56,8 +56,33 @@ build:
   docker build --build-arg SETUPTOOLS_SCM_PRETEND_VERSION={{version}} --target lambda-enricher -t {{container_name}}-enricher:{{version}} .
   docker build --build-arg SETUPTOOLS_SCM_PRETEND_VERSION={{version}} --target lambda-parser -t {{container_name}}-parser:{{version}} .
 
+# Fail fast if the private deploy config is missing, warn if it's off master.
+# A missing cdk-config.yaml makes the stack synth WITHOUT a custom domain, which
+# silently tears down the Route53 records and ACM cert on deploy (see config.py).
+_check-deploy-config:
+  #!/usr/bin/env bash
+  set -euo pipefail
+  config_dir="${GAMATRIX_CONFIG_DIR:-{{justfile_directory()}}/../gamatrix-configs}"
+  config_file="$config_dir/cdk-config.yaml"
+  if [[ ! -f "$config_file" ]]; then
+    echo "ERROR: deploy config not found at $config_file" >&2
+    echo "       Deploying without it removes the custom domain, deleting the" >&2
+    echo "       Route53 alias records and ACM cert. Restore the gamatrix-configs" >&2
+    echo "       checkout (or set GAMATRIX_CONFIG_DIR) before deploying." >&2
+    exit 1
+  fi
+  if git -C "$config_dir" rev-parse --git-dir >/dev/null 2>&1; then
+    branch="$(git -C "$config_dir" rev-parse --abbrev-ref HEAD)"
+    if [[ "$branch" != "master" ]]; then
+      where="branch '$branch'"
+      [[ "$branch" == "HEAD" ]] && where="a detached HEAD"
+      echo "WARNING: gamatrix-configs is on $where, not master." >&2
+      echo "         Confirm this is the config you mean to deploy." >&2
+    fi
+  fi
+
 # Deploy infrastructure with CDK
-deploy:
+deploy: _check-deploy-config
   # cdk.json runs the app via ../../.venv/bin/python, so the cdk extra must be
   # present in .venv. `uv sync` prunes anything outside the synced set, so sync
   # dev + cdk together to keep the dev tools too.


### PR DESCRIPTION
## Why

If `cdk-config.yaml` is absent, `load_deploy_config()` returns an empty config and the stack synths **without a custom domain**. A `just deploy` in that state silently tears down the Route53 alias records and the ACM cert, and CloudFormation still reports `UPDATE_COMPLETE` because a domainless stack is a "valid" outcome.

This took `gamatrix.erikniklas.com` / `games.erikniklas.com` offline after a deploy where the `gamatrix-configs` repo was checked out to an old v1 commit that predated `cdk-config.yaml`.

## What

A `_check-deploy-config` preflight that `deploy` now depends on:

- **Hard-fails** if `cdk-config.yaml` is missing at `GAMATRIX_CONFIG_DIR` (default `../gamatrix-configs`), mirroring `config.py`'s resolution. This blocks the exact deploy that caused the outage.
- **Warns** (but proceeds) if the config repo isn't on `master`, including the detached-HEAD case behind this incident.

## Tested

- config present + on `master` → passes silently.
- missing file → `ERROR ...`, exit 1 (deploy aborts).
- detached HEAD → `WARNING: gamatrix-configs is on a detached HEAD, not master.`, exit 0 (continues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)