### PR TITLE
Add Passkey login functionality

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -22,6 +22,12 @@ EMAIL_FROM=noreply@example.com
 # Base URL used to build password-reset links in emails.
 APP_BASE_URL=http://localhost:8088
 
+# WebAuthn relying-party scope. Production must use the stable canonical HTTPS
+# domain and explicitly list its exact origin.
+WEBAUTHN_RP_ID=localhost
+WEBAUTHN_RP_NAME=Gamatrix
+WEBAUTHN_ORIGINS=["http://localhost:8088"]
+
 # How long (days) before cached IGDB data is considered stale and re-enriched.
 IGDB_STALE_DAYS=30
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Install dependencies
       # --frozen installs the exact versions in uv.lock and fails if the lock is
       # out of sync with pyproject.toml, so CI matches local and deployed builds.
-      run: uv sync --frozen --extra dev --extra ci
+      run: uv sync --frozen --extra dev --extra ci --extra cdk
 
     - name: Analyze with mypy
       run: uv run mypy

--- a/infrastructure/cdk/README.md
+++ b/infrastructure/cdk/README.md
@@ -31,14 +31,15 @@ npx cdk deploy
 ## What it creates
 
 - DynamoDB tables: `games`, `users`, `user_libraries` (+ `release_key-index` GSI),
-  `enrichment_jobs`, `metadata_overrides`, `config` (PAY_PER_REQUEST, PITR on)
+  `enrichment_jobs`, `metadata_overrides`, `config`, `passkeys`
+  (+ `user_handle-index` GSI), and TTL-enabled `auth_challenges`
+  (PAY_PER_REQUEST, PITR on)
 - S3 upload bucket (1-day lifecycle expiry, CORS for browser POST)
 - SQS enrichment queue
 - Lambdas: web (HTTP API + Mangum), enricher (SQS-triggered), parser (S3-triggered)
 - HTTP API (API Gateway v2) in front of the web Lambda
-- **If a deployment config supplies a domain** (see below): a custom domain +
-  ACM certificate (DNS-validated via the Route 53 hosted zone) + alias A-record.
-  Without it, the app is served from the default API Gateway URL.
+- Required custom domain, ACM certificate (DNS-validated via Route 53), and
+  alias A-record. The stable custom domain is the WebAuthn RP scope.
 - SES domain identity is **not** managed by this stack — verify the sender
   domain in the SES console once and it persists independently.
 - Secrets Manager secret `gamatrix/igdb` — populate after deploy:
@@ -69,9 +70,13 @@ alias_domains:
   - app.other.com
 ```
 
-If the file is absent (or omits `hosted_zone`/`site_domain`), the stack deploys
-without a custom domain or SES — the app is reached at the default API Gateway
-URL. When a domain *is* configured, the hosted zone is looked up via
+If the file is absent (or omits `hosted_zone`/`site_domain`), stack synthesis
+fails because WebAuthn
+credentials are permanently scoped to the configured RP ID. Enroll passkeys
+only after the canonical domain is stable; passkeys enrolled against an API
+Gateway hostname or an old RP ID do not transfer automatically. Alias domains
+redirect to the canonical `site_domain`. When a domain *is* configured, the
+hosted zone is looked up via
 `HostedZone.from_lookup`, so the stack must be deployed with an explicit
 account/region (set by `app.py` from `CDK_DEFAULT_ACCOUNT` / `CDK_DEFAULT_REGION`).
 

--- a/infrastructure/cdk/gamatrix_stack.py
+++ b/infrastructure/cdk/gamatrix_stack.py
@@ -82,6 +82,10 @@ class GamatrixStack(Stack):
         super().__init__(scope, construct_id, **kwargs)
 
         cfg = deploy_config or DeployConfig()
+        if not cfg.has_custom_domain:
+            raise ValueError(
+                "A stable custom site_domain is required for production passkeys."
+            )
 
         tables = self._create_tables()
         upload_bucket = self._create_bucket()
@@ -121,9 +125,8 @@ class GamatrixStack(Stack):
         )
         self._create_ssm_params()
 
-        # Custom domain / SES are wired only when the deployment config supplies
-        # a hosted zone + site domain. Otherwise the stack still deploys and the
-        # app is reached via the default API Gateway URL.
+        # The custom domain is the stable WebAuthn RP scope. Alias domains are
+        # wired for reachability and redirected by the app to this canonical host.
         hosted_zone = None
         alias_hosted_zone = None
         if cfg.has_custom_domain:
@@ -147,6 +150,10 @@ class GamatrixStack(Stack):
             "JWT_SECRET_NAME": jwt_secret.secret_name,
             "EMAIL_FROM": cfg.email_from or DEFAULT_EMAIL_FROM,
             "IGDB_STALE_DAYS": "30",
+            "WEBAUTHN_RP_ID": cfg.site_domain or "",
+            "WEBAUTHN_ORIGINS": (
+                f'["https://{cfg.site_domain}"]' if cfg.site_domain else "[]"
+            ),
         }
 
         web_fn = self._lambda(
@@ -296,7 +303,9 @@ class GamatrixStack(Stack):
     def _create_tables(self) -> dict[str, dynamodb.Table]:
         tables: dict[str, dynamodb.Table] = {}
 
-        def table(name: str, pk: str, sk: str | None = None) -> dynamodb.Table:
+        def table(
+            name: str, pk: str, sk: str | None = None, ttl: str | None = None
+        ) -> dynamodb.Table:
             t = dynamodb.Table(
                 self,
                 name,
@@ -312,6 +321,7 @@ class GamatrixStack(Stack):
                 billing_mode=dynamodb.BillingMode.PAY_PER_REQUEST,
                 removal_policy=RemovalPolicy.RETAIN,
                 point_in_time_recovery=True,
+                time_to_live_attribute=ttl,
             )
             tables[name] = t
             return t
@@ -329,6 +339,14 @@ class GamatrixStack(Stack):
         table("metadata_overrides", "slug")
         table("profile_pics", "user_id")
         table("config", "key")
+        passkeys = table("passkeys", "credential_id")
+        passkeys.add_global_secondary_index(
+            index_name="user_handle-index",
+            partition_key=dynamodb.Attribute(
+                name="user_handle", type=dynamodb.AttributeType.STRING
+            ),
+        )
+        table("auth_challenges", "challenge_id", ttl="expires_at")
         return tables
 
     def _create_bucket(self) -> s3.Bucket:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,7 @@ plugins = ["pydantic.mypy"]
 addopts = "--cov=gamatrix --cov-branch"
 pythonpath = ["src"]
 asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"
 testpaths = ["tests"]
 
 [tool.black]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
     "rapidfuzz==3.11.0",
     "itsdangerous==2.2.0",
     "pillow==11.1.0",
+    "webauthn==2.7.0",
 ]
 
 [project.optional-dependencies]
@@ -78,7 +79,7 @@ where = ["src"]
 
 [tool.setuptools.package-data]
 "gamatrix.templates" = ["*.jinja"]
-"gamatrix.static" = ["*.png", "*.jpg", "*.css"]
+"gamatrix.static" = ["*.png", "*.jpg", "*.css", "*.js"]
 "gamatrix.static.profile_img" = ["*.png", "*.jpg"]
 
 [tool.mypy]

--- a/scripts/init_local.py
+++ b/scripts/init_local.py
@@ -75,6 +75,28 @@ def _table_defs(s):
             "KeySchema": [{"AttributeName": "key", "KeyType": "HASH"}],
             "AttributeDefinitions": [{"AttributeName": "key", "AttributeType": "S"}],
         },
+        {
+            "TableName": s.passkeys_table,
+            "KeySchema": [{"AttributeName": "credential_id", "KeyType": "HASH"}],
+            "AttributeDefinitions": [
+                {"AttributeName": "credential_id", "AttributeType": "S"},
+                {"AttributeName": "user_handle", "AttributeType": "S"},
+            ],
+            "GlobalSecondaryIndexes": [
+                {
+                    "IndexName": "user_handle-index",
+                    "KeySchema": [{"AttributeName": "user_handle", "KeyType": "HASH"}],
+                    "Projection": {"ProjectionType": "ALL"},
+                }
+            ],
+        },
+        {
+            "TableName": s.auth_challenges_table,
+            "KeySchema": [{"AttributeName": "challenge_id", "KeyType": "HASH"}],
+            "AttributeDefinitions": [
+                {"AttributeName": "challenge_id", "AttributeType": "S"}
+            ],
+        },
     ]
 
 
@@ -91,6 +113,14 @@ def create_tables(settings) -> None:
             log.info("Table %s already exists", name)
             continue
         ddb.create_table(BillingMode="PAY_PER_REQUEST", **defn)
+        if name == settings.auth_challenges_table:
+            ddb.update_time_to_live(
+                TableName=name,
+                TimeToLiveSpecification={
+                    "Enabled": True,
+                    "AttributeName": "expires_at",
+                },
+            )
         log.info("Created table %s", name)
 
 

--- a/src/gamatrix/app.py
+++ b/src/gamatrix/app.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
+from urllib.parse import urlparse
 
 from fastapi import FastAPI, Request
 from fastapi.responses import RedirectResponse
@@ -35,6 +36,25 @@ app.include_router(auth_router)
 app.include_router(games_router)
 app.include_router(preferences_router)
 app.include_router(upload_router)
+
+
+@app.middleware("http")
+async def _canonical_domain(request: Request, call_next):
+    """Keep production WebAuthn ceremonies scoped to one stable hostname."""
+    from gamatrix.config import get_settings
+
+    settings = get_settings()
+    canonical = urlparse(settings.app_base_url)
+    if (
+        not settings.local_dev
+        and canonical.hostname
+        and request.url.hostname != canonical.hostname
+    ):
+        target = f"{settings.app_base_url.rstrip('/')}{request.url.path}"
+        if request.url.query:
+            target = f"{target}?{request.url.query}"
+        return RedirectResponse(url=target, status_code=308)
+    return await call_next(request)
 
 
 @app.exception_handler(RedirectToLogin)

--- a/src/gamatrix/auth/passkeys.py
+++ b/src/gamatrix/auth/passkeys.py
@@ -1,4 +1,13 @@
-"""WebAuthn passkey ceremonies and persistence."""
+"""WebAuthn passkey ceremonies and persistence.
+
+Coordinates WebAuthn registration and authentication flows using the
+py_webauthn library. Registration requires password confirmation and
+generates WebAuthn creation options; verification stores the credential
+after validating the attestation. Authentication is passwordless; options
+are generated for any user, and verification returns the authenticated user
+after validating the assertion. Challenge state is stored in DynamoDB with
+TTL to prevent replay attacks.
+"""
 
 from __future__ import annotations
 
@@ -38,6 +47,13 @@ def _new_challenge(
     user_handle: str | None = None,
     friendly_name: str | None = None,
 ) -> tuple[str, bytes]:
+    """Generate and store a new WebAuthn challenge for a ceremony.
+
+    Creates a cryptographically random challenge, stores it in DynamoDB
+    with expiration, and returns both the challenge_id (for client reference)
+    and raw challenge bytes (for option generation). Optional user_handle
+    and friendly_name are stored for validation during verification.
+    """
     challenge_id = secrets.token_urlsafe(32)
     challenge = secrets.token_bytes(32)
     now = int(datetime.now(timezone.utc).timestamp())
@@ -56,6 +72,11 @@ def _new_challenge(
 
 
 def _load_challenge(repo: Repository, challenge_id: str, ceremony: str) -> dict:
+    """Load and validate a WebAuthn challenge from storage.
+
+    Retrieves the challenge and verifies it matches the expected ceremony type
+    and has not expired. Raises PasskeyError if invalid or expired.
+    """
     item = repo.get_auth_challenge(challenge_id)
     now = int(datetime.now(timezone.utc).timestamp())
     if not item or item.get("ceremony") != ceremony or item["expires_at"] < now:
@@ -64,6 +85,12 @@ def _load_challenge(repo: Repository, challenge_id: str, ceremony: str) -> dict:
 
 
 def _user_handle(repo: Repository, user: dict) -> str:
+    """Get or generate a WebAuthn user handle for the user.
+
+    Returns the existing webauthn_user_id if present, otherwise generates
+    a new random identifier, stores it on the user record, and returns it.
+    The user handle is used as the WebAuthn user.id (opaque identifier).
+    """
     existing = user.get("webauthn_user_id")
     if existing:
         return str(existing)

--- a/src/gamatrix/auth/passkeys.py
+++ b/src/gamatrix/auth/passkeys.py
@@ -1,0 +1,214 @@
+"""WebAuthn passkey ceremonies and persistence."""
+
+from __future__ import annotations
+
+import json
+import secrets
+from datetime import datetime, timezone
+from typing import Any
+
+from webauthn import (
+    generate_authentication_options,
+    generate_registration_options,
+    options_to_json,
+    verify_authentication_response,
+    verify_registration_response,
+)
+from webauthn.helpers import base64url_to_bytes, bytes_to_base64url
+from webauthn.helpers.structs import (
+    AuthenticatorSelectionCriteria,
+    PublicKeyCredentialDescriptor,
+    ResidentKeyRequirement,
+    UserVerificationRequirement,
+)
+
+from gamatrix.config import Settings, get_settings
+from gamatrix.helpers import now_iso
+from gamatrix.storage.dynamo import Repository
+
+
+class PasskeyError(Exception):
+    """A passkey ceremony could not be completed."""
+
+
+def _new_challenge(
+    repo: Repository,
+    settings: Settings,
+    ceremony: str,
+    user_handle: str | None = None,
+    friendly_name: str | None = None,
+) -> tuple[str, bytes]:
+    challenge_id = secrets.token_urlsafe(32)
+    challenge = secrets.token_bytes(32)
+    now = int(datetime.now(timezone.utc).timestamp())
+    item: dict[str, Any] = {
+        "challenge_id": challenge_id,
+        "challenge": bytes_to_base64url(challenge),
+        "ceremony": ceremony,
+        "expires_at": now + settings.webauthn_challenge_ttl_seconds,
+    }
+    if user_handle:
+        item["user_handle"] = user_handle
+    if friendly_name:
+        item["friendly_name"] = friendly_name
+    repo.put_auth_challenge(item)
+    return challenge_id, challenge
+
+
+def _load_challenge(repo: Repository, challenge_id: str, ceremony: str) -> dict:
+    item = repo.get_auth_challenge(challenge_id)
+    now = int(datetime.now(timezone.utc).timestamp())
+    if not item or item.get("ceremony") != ceremony or item["expires_at"] < now:
+        raise PasskeyError("The passkey request has expired or is invalid.")
+    return item
+
+
+def _user_handle(repo: Repository, user: dict) -> str:
+    existing = user.get("webauthn_user_id")
+    if existing:
+        return str(existing)
+    return repo.ensure_webauthn_user_id(
+        user["email"], bytes_to_base64url(secrets.token_bytes(32))
+    )
+
+
+def registration_options(
+    repo: Repository,
+    user: dict,
+    friendly_name: str,
+    settings: Settings | None = None,
+) -> dict:
+    settings = settings or get_settings()
+    name = friendly_name.strip()
+    if not name or len(name) > 100:
+        raise PasskeyError("Passkey name must be between 1 and 100 characters.")
+    user_handle = _user_handle(repo, user)
+    challenge_id, challenge = _new_challenge(
+        repo, settings, "registration", user_handle, name
+    )
+    existing = repo.list_passkeys(user_handle)
+    options = generate_registration_options(
+        rp_id=settings.webauthn_rp_id,
+        rp_name=settings.webauthn_rp_name,
+        user_id=base64url_to_bytes(user_handle),
+        user_name=user["email"],
+        user_display_name=user.get("username", user["email"]),
+        challenge=challenge,
+        timeout=settings.webauthn_challenge_ttl_seconds * 1000,
+        authenticator_selection=AuthenticatorSelectionCriteria(
+            resident_key=ResidentKeyRequirement.REQUIRED,
+            require_resident_key=True,
+            user_verification=UserVerificationRequirement.REQUIRED,
+        ),
+        exclude_credentials=[
+            PublicKeyCredentialDescriptor(id=base64url_to_bytes(item["credential_id"]))
+            for item in existing
+        ],
+    )
+    return {
+        "challenge_id": challenge_id,
+        "publicKey": json.loads(options_to_json(options)),
+    }
+
+
+def verify_registration(
+    repo: Repository,
+    user: dict,
+    challenge_id: str,
+    credential: dict,
+    settings: Settings | None = None,
+) -> dict:
+    settings = settings or get_settings()
+    challenge = _load_challenge(repo, challenge_id, "registration")
+    user_handle = _user_handle(repo, user)
+    if challenge.get("user_handle") != user_handle:
+        raise PasskeyError("The passkey request does not belong to this account.")
+    try:
+        verified = verify_registration_response(
+            credential=credential,
+            expected_challenge=base64url_to_bytes(challenge["challenge"]),
+            expected_rp_id=settings.webauthn_rp_id,
+            expected_origin=settings.webauthn_origins,
+            require_user_verification=True,
+        )
+    except Exception as exc:
+        raise PasskeyError("Passkey registration verification failed.") from exc
+    if not repo.consume_auth_challenge(challenge_id):
+        raise PasskeyError("The passkey request has already been used.")
+
+    credential_id = bytes_to_base64url(verified.credential_id)
+    response = credential.get("response", {})
+    passkey = {
+        "credential_id": credential_id,
+        "public_key": bytes_to_base64url(verified.credential_public_key),
+        "user_handle": user_handle,
+        "email": user["email"].lower(),
+        "sign_count": verified.sign_count,
+        "transports": response.get("transports", []),
+        "backup_eligible": verified.credential_device_type.value == "multi_device",
+        "backed_up": verified.credential_backed_up,
+        "friendly_name": challenge["friendly_name"],
+        "created_at": now_iso(),
+        "last_used_at": None,
+    }
+    if not repo.put_passkey(passkey):
+        raise PasskeyError("That passkey is already registered.")
+    return passkey
+
+
+def authentication_options(repo: Repository, settings: Settings | None = None) -> dict:
+    settings = settings or get_settings()
+    challenge_id, challenge = _new_challenge(repo, settings, "authentication")
+    options = generate_authentication_options(
+        rp_id=settings.webauthn_rp_id,
+        challenge=challenge,
+        timeout=settings.webauthn_challenge_ttl_seconds * 1000,
+        user_verification=UserVerificationRequirement.REQUIRED,
+    )
+    return {
+        "challenge_id": challenge_id,
+        "publicKey": json.loads(options_to_json(options)),
+    }
+
+
+def verify_authentication(
+    repo: Repository,
+    challenge_id: str,
+    credential: dict,
+    settings: Settings | None = None,
+) -> dict:
+    settings = settings or get_settings()
+    challenge = _load_challenge(repo, challenge_id, "authentication")
+    passkey = repo.get_passkey(credential.get("id", ""))
+    if not passkey:
+        raise PasskeyError("Unknown passkey.")
+    supplied_handle = credential.get("response", {}).get("userHandle")
+    if supplied_handle and supplied_handle != passkey["user_handle"]:
+        raise PasskeyError("Passkey user handle does not match.")
+    try:
+        verified = verify_authentication_response(
+            credential=credential,
+            expected_challenge=base64url_to_bytes(challenge["challenge"]),
+            expected_rp_id=settings.webauthn_rp_id,
+            expected_origin=settings.webauthn_origins,
+            credential_public_key=base64url_to_bytes(passkey["public_key"]),
+            credential_current_sign_count=passkey["sign_count"],
+            require_user_verification=True,
+        )
+    except Exception as exc:
+        raise PasskeyError("Passkey authentication verification failed.") from exc
+    if not repo.consume_auth_challenge(challenge_id):
+        raise PasskeyError("The passkey request has already been used.")
+
+    if not repo.update_passkey_after_authentication(
+        passkey["credential_id"],
+        passkey["sign_count"],
+        verified.new_sign_count,
+        verified.credential_backed_up,
+        now_iso(),
+    ):
+        raise PasskeyError("The passkey signature counter was already used.")
+    user = repo.get_user(passkey["email"])
+    if not user or user.get("webauthn_user_id") != passkey["user_handle"]:
+        raise PasskeyError("The passkey account no longer exists.")
+    return user

--- a/src/gamatrix/auth/routes.py
+++ b/src/gamatrix/auth/routes.py
@@ -121,7 +121,7 @@ def passkey_registration_options(
     try:
         return passkeys.registration_options(repo, user, body.friendly_name)
     except passkeys.PasskeyError as exc:
-        raise _passkey_error(exc)
+        raise _passkey_error(exc) from exc
 
 
 @router.post("/passkeys/register/verify")
@@ -135,7 +135,7 @@ def passkey_registration_verify(
             repo, user, body.challenge_id, body.credential
         )
     except passkeys.PasskeyError as exc:
-        raise _passkey_error(exc)
+        raise _passkey_error(exc) from exc
 
 
 @router.post("/passkeys/authenticate/options")
@@ -151,7 +151,7 @@ def passkey_authentication_verify(
     try:
         user = passkeys.verify_authentication(repo, body.challenge_id, body.credential)
     except passkeys.PasskeyError as exc:
-        raise _passkey_error(exc)
+        raise _passkey_error(exc) from exc
     response = JSONResponse({"redirect": "/games"})
     response.set_cookie(
         value=service.create_session_token(user["email"]), **_cookie_kwargs()
@@ -171,8 +171,16 @@ def delete_passkey(
             status_code=status.HTTP_403_FORBIDDEN, detail="Wrong password."
         )
     user_handle = user.get("webauthn_user_id")
-    if not user_handle or not repo.delete_passkey(credential_id, user_handle):
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
+    if not user_handle:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="No passkeys are registered for this account.",
+        )
+    if not repo.delete_passkey(credential_id, user_handle):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Passkey not found for this account.",
+        )
     return {"deleted": True}
 
 

--- a/src/gamatrix/auth/routes.py
+++ b/src/gamatrix/auth/routes.py
@@ -2,17 +2,32 @@
 
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, Form, Request, status
-from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi import APIRouter, Depends, Form, HTTPException, Request, status
+from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
+from pydantic import BaseModel
 
-from gamatrix.auth import service
-from gamatrix.auth.dependencies import get_repo
+from gamatrix.auth import passkeys, service
+from gamatrix.auth.dependencies import current_user, current_user_api, get_repo
 from gamatrix.auth.service import COOKIE_NAME
 from gamatrix.config import get_settings
 from gamatrix.storage.dynamo import Repository
 from gamatrix.templating import templates
 
 router = APIRouter(prefix="/auth", tags=["auth"])
+
+
+class RegistrationOptionsRequest(BaseModel):
+    password: str
+    friendly_name: str
+
+
+class CeremonyVerificationRequest(BaseModel):
+    challenge_id: str
+    credential: dict
+
+
+class DeletePasskeyRequest(BaseModel):
+    password: str
 
 
 def _cookie_kwargs() -> dict:
@@ -56,6 +71,117 @@ def logout():
     response = RedirectResponse(url="/auth/login", status_code=status.HTTP_302_FOUND)
     response.delete_cookie(COOKIE_NAME)
     return response
+
+
+def _passkey_error(exc: passkeys.PasskeyError) -> HTTPException:
+    return HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
+
+
+@router.get("/passkeys", response_class=HTMLResponse)
+def passkey_management(
+    request: Request,
+    user: dict = Depends(current_user),
+    repo: Repository = Depends(get_repo),
+):
+    user_handle = user.get("webauthn_user_id")
+    credentials = repo.list_passkeys(user_handle) if user_handle else []
+    return templates.TemplateResponse(
+        request,
+        "passkeys.html.jinja",
+        {"user": user, "passkeys": credentials},
+    )
+
+
+@router.get("/passkeys/list")
+def list_passkeys(
+    user: dict = Depends(current_user_api),
+    repo: Repository = Depends(get_repo),
+):
+    user_handle = user.get("webauthn_user_id")
+    credentials = repo.list_passkeys(user_handle) if user_handle else []
+    return [
+        {
+            key: item.get(key)
+            for key in (
+                "credential_id",
+                "friendly_name",
+                "transports",
+                "backup_eligible",
+                "backed_up",
+                "created_at",
+                "last_used_at",
+            )
+        }
+        for item in credentials
+    ]
+
+
+@router.post("/passkeys/register/options")
+def passkey_registration_options(
+    body: RegistrationOptionsRequest,
+    user: dict = Depends(current_user_api),
+    repo: Repository = Depends(get_repo),
+):
+    if not service.authenticate(repo, user["email"], body.password):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="Wrong password."
+        )
+    try:
+        return passkeys.registration_options(repo, user, body.friendly_name)
+    except passkeys.PasskeyError as exc:
+        raise _passkey_error(exc)
+
+
+@router.post("/passkeys/register/verify")
+def passkey_registration_verify(
+    body: CeremonyVerificationRequest,
+    user: dict = Depends(current_user_api),
+    repo: Repository = Depends(get_repo),
+):
+    try:
+        return passkeys.verify_registration(
+            repo, user, body.challenge_id, body.credential
+        )
+    except passkeys.PasskeyError as exc:
+        raise _passkey_error(exc)
+
+
+@router.post("/passkeys/authenticate/options")
+def passkey_authentication_options(repo: Repository = Depends(get_repo)):
+    return passkeys.authentication_options(repo)
+
+
+@router.post("/passkeys/authenticate/verify")
+def passkey_authentication_verify(
+    body: CeremonyVerificationRequest,
+    repo: Repository = Depends(get_repo),
+):
+    try:
+        user = passkeys.verify_authentication(repo, body.challenge_id, body.credential)
+    except passkeys.PasskeyError as exc:
+        raise _passkey_error(exc)
+    response = JSONResponse({"redirect": "/games"})
+    response.set_cookie(
+        value=service.create_session_token(user["email"]), **_cookie_kwargs()
+    )
+    return response
+
+
+@router.delete("/passkeys/{credential_id}")
+def delete_passkey(
+    credential_id: str,
+    body: DeletePasskeyRequest,
+    user: dict = Depends(current_user_api),
+    repo: Repository = Depends(get_repo),
+):
+    if not service.authenticate(repo, user["email"], body.password):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="Wrong password."
+        )
+    user_handle = user.get("webauthn_user_id")
+    if not user_handle or not repo.delete_passkey(credential_id, user_handle):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
+    return {"deleted": True}
 
 
 @router.get("/forgot-password", response_class=HTMLResponse)

--- a/src/gamatrix/auth/routes.py
+++ b/src/gamatrix/auth/routes.py
@@ -77,43 +77,35 @@ def _passkey_error(exc: passkeys.PasskeyError) -> HTTPException:
     return HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
 
 
+def _passkey_credentials(user: dict, repo: Repository) -> list[dict]:
+    user_handle = user.get("webauthn_user_id")
+    return repo.list_passkeys(user_handle) if user_handle else []
+
+
 @router.get("/passkeys", response_class=HTMLResponse)
 def passkey_management(
     request: Request,
     user: dict = Depends(current_user),
     repo: Repository = Depends(get_repo),
 ):
-    user_handle = user.get("webauthn_user_id")
-    credentials = repo.list_passkeys(user_handle) if user_handle else []
     return templates.TemplateResponse(
         request,
         "passkeys.html.jinja",
-        {"user": user, "passkeys": credentials},
+        {"user": user, "passkeys": _passkey_credentials(user, repo)},
     )
 
 
-@router.get("/passkeys/list")
+@router.get("/passkeys/list", response_class=HTMLResponse)
 def list_passkeys(
-    user: dict = Depends(current_user_api),
+    request: Request,
+    user: dict = Depends(current_user),
     repo: Repository = Depends(get_repo),
 ):
-    user_handle = user.get("webauthn_user_id")
-    credentials = repo.list_passkeys(user_handle) if user_handle else []
-    return [
-        {
-            key: item.get(key)
-            for key in (
-                "credential_id",
-                "friendly_name",
-                "transports",
-                "backup_eligible",
-                "backed_up",
-                "created_at",
-                "last_used_at",
-            )
-        }
-        for item in credentials
-    ]
+    return templates.TemplateResponse(
+        request,
+        "passkeys_list.html.jinja",
+        {"passkeys": _passkey_credentials(user, repo)},
+    )
 
 
 @router.post("/passkeys/register/options")

--- a/src/gamatrix/config.py
+++ b/src/gamatrix/config.py
@@ -68,7 +68,7 @@ class Settings(BaseSettings):
     smtp_port: int = 1025
 
     # --- Behavior ---
-    app_base_url: str = "http://localhost:8080"
+    app_base_url: str = "http://localhost:8088"
     igdb_stale_days: int = 30
 
     # SSM parameter names for the title filter lists (AWS only). Locally these

--- a/src/gamatrix/config.py
+++ b/src/gamatrix/config.py
@@ -50,6 +50,10 @@ class Settings(BaseSettings):
     jwt_algorithm: str = "HS256"
     jwt_ttl_hours: int = 24
     reset_token_ttl_minutes: int = 60
+    webauthn_rp_id: str = "localhost"
+    webauthn_rp_name: str = "Gamatrix"
+    webauthn_origins: list[str] = ["http://localhost:8088"]
+    webauthn_challenge_ttl_seconds: int = 300
 
     # --- IGDB / Twitch ---
     igdb_client_id: str = ""
@@ -103,6 +107,14 @@ class Settings(BaseSettings):
         """Small key/value table; locally holds the hidden/single-player lists."""
         return f"{self.table_prefix}_config"
 
+    @property
+    def passkeys_table(self) -> str:
+        return f"{self.table_prefix}_passkeys"
+
+    @property
+    def auth_challenges_table(self) -> str:
+        return f"{self.table_prefix}_auth_challenges"
+
     @model_validator(mode="after")
     def _require_jwt_secret(self) -> "Settings":
         """Fail loudly rather than silently signing sessions with the public
@@ -116,6 +128,18 @@ class Settings(BaseSettings):
             raise ValueError(
                 "JWT_SECRET must be set in production (or set JWT_SECRET_NAME to "
                 "source it from Secrets Manager)."
+            )
+        if not self.local_dev and (
+            not self.webauthn_rp_id
+            or self.webauthn_rp_id == "localhost"
+            or not self.webauthn_origins
+            or any(
+                not origin.startswith("https://") for origin in self.webauthn_origins
+            )
+        ):
+            raise ValueError(
+                "Production passkeys require WEBAUTHN_RP_ID and explicit HTTPS "
+                "WEBAUTHN_ORIGINS for the canonical domain."
             )
         return self
 

--- a/src/gamatrix/static/passkeys.js
+++ b/src/gamatrix/static/passkeys.js
@@ -62,6 +62,20 @@
     target.hidden = false;
   }
 
+  function clearError() {
+    const target = document.getElementById("passkey-error");
+    if (!target) return;
+    target.hidden = true;
+    target.textContent = "";
+  }
+
+  function setWaiting(visible) {
+    const waiting = document.getElementById("passkey-waiting");
+    if (waiting) waiting.hidden = !visible;
+    const submit = document.querySelector("#passkey-register button[type=submit]");
+    if (submit) submit.disabled = visible;
+  }
+
   async function login(mediation) {
     const ceremony = await json("/auth/passkeys/authenticate/options", { method: "POST" });
     const credential = await navigator.credentials.get({
@@ -79,10 +93,17 @@
 
   function enableLogin() {
     if (!window.PublicKeyCredential) return;
-    document.getElementById("passkey-login").addEventListener("click", () => login("required").catch(showError));
+    document.getElementById("passkey-login").addEventListener("click", () => {
+      clearError();
+      login("required").catch(showError);
+    });
     if (PublicKeyCredential.isConditionalMediationAvailable) {
       PublicKeyCredential.isConditionalMediationAvailable().then((available) => {
-        if (available) login("conditional").catch(showError);
+        if (available) {
+          login("conditional").catch(() => {
+            clearError();
+          });
+        }
       });
     }
   }
@@ -90,6 +111,7 @@
   function enableManagement() {
     document.getElementById("passkey-register").addEventListener("submit", async (event) => {
       event.preventDefault();
+      clearError();
       try {
         const form = new FormData(event.target);
         const ceremony = await json("/auth/passkeys/register/options", {
@@ -97,14 +119,17 @@
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ friendly_name: form.get("friendly_name"), password: form.get("password") }),
         });
+        setWaiting(true);
         const credential = await navigator.credentials.create({ publicKey: creationOptions(ceremony.publicKey) });
         await json("/auth/passkeys/register/verify", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ challenge_id: ceremony.challenge_id, credential: credentialJSON(credential) }),
         });
-        window.location.reload();
+        setWaiting(false);
+        window.location.assign("/auth/passkeys/list");
       } catch (error) {
+        setWaiting(false);
         showError(error);
       }
     });

--- a/src/gamatrix/static/passkeys.js
+++ b/src/gamatrix/static/passkeys.js
@@ -1,0 +1,130 @@
+(function () {
+  "use strict";
+
+  function decode(value) {
+    const base64 = value.replace(/-/g, "+").replace(/_/g, "/");
+    const bytes = atob(base64);
+    return Uint8Array.from(bytes, (char) => char.charCodeAt(0));
+  }
+
+  function encode(value) {
+    const bytes = new Uint8Array(value);
+    let binary = "";
+    bytes.forEach((byte) => { binary += String.fromCharCode(byte); });
+    return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+  }
+
+  function creationOptions(options) {
+    options.challenge = decode(options.challenge);
+    options.user.id = decode(options.user.id);
+    (options.excludeCredentials || []).forEach((item) => { item.id = decode(item.id); });
+    return options;
+  }
+
+  function requestOptions(options) {
+    options.challenge = decode(options.challenge);
+    (options.allowCredentials || []).forEach((item) => { item.id = decode(item.id); });
+    return options;
+  }
+
+  function credentialJSON(credential) {
+    const response = credential.response;
+    const result = {
+      id: credential.id,
+      rawId: encode(credential.rawId),
+      type: credential.type,
+      authenticatorAttachment: credential.authenticatorAttachment,
+      response: {
+        clientDataJSON: encode(response.clientDataJSON),
+      },
+    };
+    if (response.attestationObject) {
+      result.response.attestationObject = encode(response.attestationObject);
+      result.response.transports = response.getTransports ? response.getTransports() : [];
+    } else {
+      result.response.authenticatorData = encode(response.authenticatorData);
+      result.response.signature = encode(response.signature);
+      result.response.userHandle = response.userHandle ? encode(response.userHandle) : null;
+    }
+    return result;
+  }
+
+  async function json(url, options) {
+    const response = await fetch(url, options);
+    const body = await response.json();
+    if (!response.ok) throw new Error(body.detail || "Passkey request failed.");
+    return body;
+  }
+
+  function showError(error) {
+    const target = document.getElementById("passkey-error");
+    target.textContent = error.message || String(error);
+    target.hidden = false;
+  }
+
+  async function login(mediation) {
+    const ceremony = await json("/auth/passkeys/authenticate/options", { method: "POST" });
+    const credential = await navigator.credentials.get({
+      publicKey: requestOptions(ceremony.publicKey),
+      mediation: mediation,
+    });
+    if (!credential) return;
+    const result = await json("/auth/passkeys/authenticate/verify", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ challenge_id: ceremony.challenge_id, credential: credentialJSON(credential) }),
+    });
+    window.location.assign(result.redirect);
+  }
+
+  function enableLogin() {
+    if (!window.PublicKeyCredential) return;
+    document.getElementById("passkey-login").addEventListener("click", () => login("required").catch(showError));
+    if (PublicKeyCredential.isConditionalMediationAvailable) {
+      PublicKeyCredential.isConditionalMediationAvailable().then((available) => {
+        if (available) login("conditional").catch(showError);
+      });
+    }
+  }
+
+  function enableManagement() {
+    document.getElementById("passkey-register").addEventListener("submit", async (event) => {
+      event.preventDefault();
+      try {
+        const form = new FormData(event.target);
+        const ceremony = await json("/auth/passkeys/register/options", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ friendly_name: form.get("friendly_name"), password: form.get("password") }),
+        });
+        const credential = await navigator.credentials.create({ publicKey: creationOptions(ceremony.publicKey) });
+        await json("/auth/passkeys/register/verify", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ challenge_id: ceremony.challenge_id, credential: credentialJSON(credential) }),
+        });
+        window.location.reload();
+      } catch (error) {
+        showError(error);
+      }
+    });
+    document.querySelectorAll(".delete-passkey").forEach((button) => {
+      button.addEventListener("click", async () => {
+        const password = window.prompt("Confirm your current password to delete this passkey:");
+        if (!password) return;
+        try {
+          await json(`/auth/passkeys/${encodeURIComponent(button.dataset.credentialId)}`, {
+            method: "DELETE",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ password: password }),
+          });
+          window.location.reload();
+        } catch (error) {
+          showError(error);
+        }
+      });
+    });
+  }
+
+  window.gamatrixPasskeys = { enableLogin, enableManagement };
+}());

--- a/src/gamatrix/static/style.css
+++ b/src/gamatrix/static/style.css
@@ -124,5 +124,19 @@ table.results td.unowned { background-color: var(--unowned); }
 .passkey-list { list-style: none; padding: 0; }
 .passkey-list li { display: flex; gap: 1rem; align-items: center; margin: 0.75rem 0; }
 .passkey-list li .muted { flex: 1; }
+.help-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1rem;
+  height: 1rem;
+  border: 1px solid #888;
+  border-radius: 50%;
+  color: #bbb;
+  cursor: help;
+  font-size: 0.75rem;
+  line-height: 1;
+}
+.help-icon:focus { outline: 1px solid var(--accent); outline-offset: 2px; }
 .error { color: #ff8a80; }
 .muted { color: #aaa; font-size: 0.9rem; }

--- a/src/gamatrix/static/style.css
+++ b/src/gamatrix/static/style.css
@@ -111,7 +111,7 @@ table.results td.unowned { background-color: var(--unowned); }
   padding: 1.5rem;
 }
 .card h2 { margin-top: 0; }
-.card input[type=email], .card input[type=password] {
+.card input[type=email], .card input[type=password], .card input[type=text] {
   width: 100%;
   padding: 8px;
   margin: 6px 0 12px;
@@ -119,5 +119,10 @@ table.results td.unowned { background-color: var(--unowned); }
   border-radius: 4px;
   border: 1px solid #888;
 }
+.card.wide { max-width: 720px; margin: 1rem auto; }
+.separator { color: #aaa; text-align: center; }
+.passkey-list { list-style: none; padding: 0; }
+.passkey-list li { display: flex; gap: 1rem; align-items: center; margin: 0.75rem 0; }
+.passkey-list li .muted { flex: 1; }
 .error { color: #ff8a80; }
 .muted { color: #aaa; font-size: 0.9rem; }

--- a/src/gamatrix/storage/dynamo.py
+++ b/src/gamatrix/storage/dynamo.py
@@ -382,18 +382,6 @@ class Repository:
         last_used_at: str,
     ) -> bool:
         """Update usage state without accepting a concurrent counter replay."""
-        condition = (
-            "sign_count = :expected"
-            if expected_sign_count or new_sign_count
-            else "attribute_exists(credential_id)"
-        )
-        values = {
-            ":new": new_sign_count,
-            ":backed_up": backed_up,
-            ":last_used": last_used_at,
-        }
-        if expected_sign_count or new_sign_count:
-            values[":expected"] = expected_sign_count
         try:
             self._table(self.settings.passkeys_table).update_item(
                 Key={"credential_id": credential_id},
@@ -401,8 +389,15 @@ class Repository:
                     "SET sign_count = :new, backed_up = :backed_up, "
                     "last_used_at = :last_used"
                 ),
-                ConditionExpression=condition,
-                ExpressionAttributeValues=_to_dynamo(values),
+                ConditionExpression="sign_count = :expected",
+                ExpressionAttributeValues=_to_dynamo(
+                    {
+                        ":new": new_sign_count,
+                        ":backed_up": backed_up,
+                        ":last_used": last_used_at,
+                        ":expected": expected_sign_count,
+                    }
+                ),
             )
             return True
         except self._resource.meta.client.exceptions.ConditionalCheckFailedException:

--- a/src/gamatrix/storage/dynamo.py
+++ b/src/gamatrix/storage/dynamo.py
@@ -114,6 +114,18 @@ class Repository:
         user = {**user, "email": user["email"].lower()}
         self._table(self.settings.users_table).put_item(Item=_to_dynamo(user))
 
+    def ensure_webauthn_user_id(self, email: str, user_handle: str) -> str:
+        """Assign a stable opaque WebAuthn user handle exactly once."""
+        response = self._table(self.settings.users_table).update_item(
+            Key={"email": email.lower()},
+            UpdateExpression=(
+                "SET webauthn_user_id = if_not_exists(webauthn_user_id, :v)"
+            ),
+            ExpressionAttributeValues={":v": user_handle},
+            ReturnValues="ALL_NEW",
+        )
+        return str(response["Attributes"]["webauthn_user_id"])
+
     def update_user(self, email: str, attrs: dict) -> None:
         if not attrs:
             return
@@ -311,6 +323,112 @@ class Repository:
         self._table(self.settings.config_table).put_item(
             Item=_to_dynamo({"key": key, "value": value})
         )
+
+    # ------------------------------------------------------------------
+    # passkeys and one-time WebAuthn challenges
+    # ------------------------------------------------------------------
+    def put_passkey(self, passkey: dict) -> bool:
+        try:
+            self._table(self.settings.passkeys_table).put_item(
+                Item=_to_dynamo(passkey),
+                ConditionExpression="attribute_not_exists(credential_id)",
+            )
+            return True
+        except self._resource.meta.client.exceptions.ConditionalCheckFailedException:
+            return False
+
+    def get_passkey(self, credential_id: str) -> dict | None:
+        response = self._table(self.settings.passkeys_table).get_item(
+            Key={"credential_id": credential_id}
+        )
+        item = response.get("Item")
+        return _from_dynamo(item) if item else None
+
+    def list_passkeys(self, user_handle: str) -> list[dict]:
+        return self._query_all(
+            self.settings.passkeys_table,
+            IndexName="user_handle-index",
+            KeyConditionExpression=Key("user_handle").eq(user_handle),
+        )
+
+    def delete_passkey(self, credential_id: str, user_handle: str) -> bool:
+        try:
+            self._table(self.settings.passkeys_table).delete_item(
+                Key={"credential_id": credential_id},
+                ConditionExpression="user_handle = :user_handle",
+                ExpressionAttributeValues={":user_handle": user_handle},
+            )
+            return True
+        except self._resource.meta.client.exceptions.ConditionalCheckFailedException:
+            return False
+
+    def update_passkey(self, credential_id: str, attrs: dict) -> None:
+        names = {f"#{key}": key for key in attrs}
+        values = {f":{key}": _to_dynamo(value) for key, value in attrs.items()}
+        expression = "SET " + ", ".join(f"#{key} = :{key}" for key in attrs)
+        self._table(self.settings.passkeys_table).update_item(
+            Key={"credential_id": credential_id},
+            UpdateExpression=expression,
+            ExpressionAttributeNames=names,
+            ExpressionAttributeValues=values,
+        )
+
+    def update_passkey_after_authentication(
+        self,
+        credential_id: str,
+        expected_sign_count: int,
+        new_sign_count: int,
+        backed_up: bool,
+        last_used_at: str,
+    ) -> bool:
+        """Update usage state without accepting a concurrent counter replay."""
+        condition = (
+            "sign_count = :expected"
+            if expected_sign_count or new_sign_count
+            else "attribute_exists(credential_id)"
+        )
+        values = {
+            ":new": new_sign_count,
+            ":backed_up": backed_up,
+            ":last_used": last_used_at,
+        }
+        if expected_sign_count or new_sign_count:
+            values[":expected"] = expected_sign_count
+        try:
+            self._table(self.settings.passkeys_table).update_item(
+                Key={"credential_id": credential_id},
+                UpdateExpression=(
+                    "SET sign_count = :new, backed_up = :backed_up, "
+                    "last_used_at = :last_used"
+                ),
+                ConditionExpression=condition,
+                ExpressionAttributeValues=_to_dynamo(values),
+            )
+            return True
+        except self._resource.meta.client.exceptions.ConditionalCheckFailedException:
+            return False
+
+    def put_auth_challenge(self, challenge: dict) -> None:
+        self._table(self.settings.auth_challenges_table).put_item(
+            Item=_to_dynamo(challenge)
+        )
+
+    def get_auth_challenge(self, challenge_id: str) -> dict | None:
+        response = self._table(self.settings.auth_challenges_table).get_item(
+            Key={"challenge_id": challenge_id}
+        )
+        item = response.get("Item")
+        return _from_dynamo(item) if item else None
+
+    def consume_auth_challenge(self, challenge_id: str) -> bool:
+        try:
+            self._table(self.settings.auth_challenges_table).delete_item(
+                Key={"challenge_id": challenge_id},
+                ConditionExpression="attribute_exists(challenge_id)",
+            )
+            return True
+        except self._resource.meta.client.exceptions.ConditionalCheckFailedException:
+            return False
 
     # ------------------------------------------------------------------
     # internal

--- a/src/gamatrix/storage/dynamo.py
+++ b/src/gamatrix/storage/dynamo.py
@@ -383,6 +383,8 @@ class Repository:
     ) -> bool:
         """Update usage state without accepting a concurrent counter replay."""
         try:
+            # Some synced authenticators keep reporting a zero counter forever, so
+            # the single-use WebAuthn challenge remains the primary replay guard.
             self._table(self.settings.passkeys_table).update_item(
                 Key={"credential_id": credential_id},
                 UpdateExpression=(

--- a/src/gamatrix/templates/login.html.jinja
+++ b/src/gamatrix/templates/login.html.jinja
@@ -6,11 +6,16 @@
     {% if error %}<p class="error">{{ error }}</p>{% endif %}
     <form method="post" action="/auth/login">
         <label for="email">Email</label>
-        <input type="email" id="email" name="email" required autofocus>
+        <input type="email" id="email" name="email" required autofocus autocomplete="username webauthn">
         <label for="password">Password</label>
         <input type="password" id="password" name="password" required>
         <button type="submit">Sign in</button>
     </form>
+    <p class="separator">or</p>
+    <button type="button" id="passkey-login" class="secondary">Sign in with a passkey</button>
+    <p id="passkey-error" class="error" hidden></p>
     <p class="muted"><a href="/auth/forgot-password">Forgot your password?</a></p>
 </div>
+<script src="/static/passkeys.js"></script>
+<script>window.gamatrixPasskeys.enableLogin();</script>
 {% endblock %}

--- a/src/gamatrix/templates/passkeys.html.jinja
+++ b/src/gamatrix/templates/passkeys.html.jinja
@@ -11,11 +11,16 @@
     <p class="muted">Passkeys can use this device, a synced provider, a phone, or a compatible security key.</p>
     <form id="passkey-register">
         <label for="friendly_name">Passkey name</label>
-        <input type="text" id="friendly_name" name="friendly_name" maxlength="100" required>
-        <label for="current_password">Current password</label>
+        <input type="text" id="friendly_name" name="friendly_name" maxlength="100"
+               value="Gamatrix passkey for {{ user.username }}" required>
+        <label for="current_password">Current password
+            <span class="help-icon" title="Required to verify your identity before adding a passkey"
+                  aria-label="Required to verify your identity before adding a passkey" tabindex="0">?</span>
+        </label>
         <input type="password" id="current_password" name="password" required autocomplete="current-password">
         <button type="submit">Add passkey</button>
     </form>
+    <p id="passkey-waiting" class="muted" hidden>Waiting for passkey creation to complete...</p>
     <p id="passkey-error" class="error" hidden></p>
 </div>
 
@@ -29,7 +34,7 @@
             <span class="muted">
                 {% if passkey.backup_eligible %}sync-capable{% else %}device-bound{% endif %}
                 {% if passkey.backed_up %}, backed up{% endif %}
-                · added {{ passkey.created_at[:10] }}
+                {% if passkey.created_at %} - added {{ passkey.created_at[:10] }}{% endif %}
             </span>
             <button type="button" class="secondary delete-passkey"
                     data-credential-id="{{ passkey.credential_id }}">Delete</button>

--- a/src/gamatrix/templates/passkeys.html.jinja
+++ b/src/gamatrix/templates/passkeys.html.jinja
@@ -1,0 +1,45 @@
+{% extends "base.html.jinja" %}
+{% block title %}gamatrix — passkeys{% endblock %}
+{% block body %}
+<div class="topbar">
+    <h2>Passkeys</h2>
+    <div class="right"><a href="/preferences">Back to preferences</a></div>
+</div>
+
+<div class="card wide">
+    <h3>Add a passkey</h3>
+    <p class="muted">Passkeys can use this device, a synced provider, a phone, or a compatible security key.</p>
+    <form id="passkey-register">
+        <label for="friendly_name">Passkey name</label>
+        <input type="text" id="friendly_name" name="friendly_name" maxlength="100" required>
+        <label for="current_password">Current password</label>
+        <input type="password" id="current_password" name="password" required autocomplete="current-password">
+        <button type="submit">Add passkey</button>
+    </form>
+    <p id="passkey-error" class="error" hidden></p>
+</div>
+
+<div class="card wide">
+    <h3>Registered passkeys</h3>
+    {% if passkeys %}
+    <ul class="passkey-list">
+        {% for passkey in passkeys %}
+        <li>
+            <strong>{{ passkey.friendly_name }}</strong>
+            <span class="muted">
+                {% if passkey.backup_eligible %}sync-capable{% else %}device-bound{% endif %}
+                {% if passkey.backed_up %}, backed up{% endif %}
+                · added {{ passkey.created_at[:10] }}
+            </span>
+            <button type="button" class="secondary delete-passkey"
+                    data-credential-id="{{ passkey.credential_id }}">Delete</button>
+        </li>
+        {% endfor %}
+    </ul>
+    {% else %}
+    <p class="muted">No passkeys registered.</p>
+    {% endif %}
+</div>
+<script src="/static/passkeys.js"></script>
+<script>window.gamatrixPasskeys.enableManagement();</script>
+{% endblock %}

--- a/src/gamatrix/templates/passkeys_list.html.jinja
+++ b/src/gamatrix/templates/passkeys_list.html.jinja
@@ -1,0 +1,28 @@
+{% extends "base.html.jinja" %}
+{% block title %}gamatrix — passkeys{% endblock %}
+{% block body %}
+<div class="topbar">
+    <h2>Passkeys</h2>
+    <div class="right"><a href="/preferences">Back to preferences</a></div>
+</div>
+
+<div class="card wide">
+    <h3>Registered passkeys</h3>
+    {% if passkeys %}
+    <ul class="passkey-list">
+        {% for passkey in passkeys %}
+        <li>
+            <strong>{{ passkey.friendly_name }}</strong>
+            <span class="muted">
+                {% if passkey.backup_eligible %}sync-capable{% else %}device-bound{% endif %}
+                {% if passkey.backed_up %}, backed up{% endif %}
+                {% if passkey.created_at %} - added {{ passkey.created_at[:10] }}{% endif %}
+            </span>
+        </li>
+        {% endfor %}
+    </ul>
+    {% else %}
+    <p class="muted">No passkeys registered.</p>
+    {% endif %}
+</div>
+{% endblock %}

--- a/src/gamatrix/templates/preferences.html.jinja
+++ b/src/gamatrix/templates/preferences.html.jinja
@@ -3,7 +3,7 @@
 {% block body %}
 <div class="topbar">
     <h2>Preferences</h2>
-    <div class="right"><a href="/games">Back to games</a></div>
+    <div class="right"><a href="/auth/passkeys">Manage passkeys</a><a href="/games">Back to games</a></div>
 </div>
 
 <form id="profile" method="post" action="/profile" class="filters"

--- a/src/gamatrix/templates/preferences.html.jinja
+++ b/src/gamatrix/templates/preferences.html.jinja
@@ -3,7 +3,7 @@
 {% block body %}
 <div class="topbar">
     <h2>Preferences</h2>
-    <div class="right"><a href="/auth/passkeys">Manage passkeys</a><a href="/games">Back to games</a></div>
+    <div class="right"><a href="/games">Back to games</a></div>
 </div>
 
 <form id="profile" method="post" action="/profile" class="filters"
@@ -62,6 +62,14 @@ async function uploadProfilePic() {
     saved.style.display = 'inline';
 }
 </script>
+
+<div class="filters">
+    <fieldset class="filter-group">
+        <legend>Passkeys</legend>
+        <button type="button" onclick="window.location.href='/auth/passkeys'">Manage passkeys</button>
+        <span class="muted">Add, review, or remove passkeys for this account.</span>
+    </fieldset>
+</div>
 
 <form id="filters" method="post" action="/preferences" class="filters"
       hx-post="/preferences" hx-swap="none"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ import os
 
 os.environ.setdefault("TABLE_PREFIX", "test")
 os.environ.setdefault("JWT_SECRET", "test-secret")
+os.environ.setdefault("LOCAL_DEV", "true")
 os.environ.setdefault("AWS_ACCESS_KEY_ID", "testing")
 os.environ.setdefault("AWS_SECRET_ACCESS_KEY", "testing")
 os.environ.setdefault("AWS_DEFAULT_REGION", "ca-central-1")
@@ -61,6 +62,7 @@ def _create_tables(settings: Settings) -> None:
         (settings.metadata_table, "slug"),
         (settings.profile_pics_table, "user_id"),
         (settings.config_table, "key"),
+        (settings.auth_challenges_table, "challenge_id"),
     ]:
         ddb.create_table(
             TableName=name,
@@ -68,6 +70,22 @@ def _create_tables(settings: Settings) -> None:
             AttributeDefinitions=[{"AttributeName": pk, "AttributeType": "S"}],
             **common,
         )
+    ddb.create_table(
+        TableName=settings.passkeys_table,
+        KeySchema=[{"AttributeName": "credential_id", "KeyType": "HASH"}],
+        AttributeDefinitions=[
+            {"AttributeName": "credential_id", "AttributeType": "S"},
+            {"AttributeName": "user_handle", "AttributeType": "S"},
+        ],
+        GlobalSecondaryIndexes=[
+            {
+                "IndexName": "user_handle-index",
+                "KeySchema": [{"AttributeName": "user_handle", "KeyType": "HASH"}],
+                "Projection": {"ProjectionType": "ALL"},
+            }
+        ],
+        **common,
+    )
 
 
 @pytest.fixture
@@ -75,6 +93,7 @@ def settings() -> Settings:
     return Settings(
         table_prefix="test",
         jwt_secret="test-secret",
+        local_dev=True,
         dynamodb_endpoint_url=None,
         s3_endpoint_url=None,
         sqs_endpoint_url=None,

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 
 from urllib.parse import parse_qs, urlparse
 
+from fastapi.testclient import TestClient
+
+from gamatrix.app import app
 from gamatrix.auth import service
+from gamatrix.config import Settings
 
 
 def test_password_hash_roundtrip():
@@ -97,3 +101,41 @@ def test_password_reset_link_url_encodes_plus_email(repo, settings, monkeypatch)
     )
     query = parse_qs(urlparse(reset_link).query)
     assert query["email"] == ["user+games@x.com"]
+
+
+def test_canonical_domain_redirects_nonlocal_requests(monkeypatch):
+    settings = Settings(
+        local_dev=False,
+        jwt_secret="secret",
+        app_base_url="https://games.example.com",
+        webauthn_rp_id="games.example.com",
+        webauthn_origins=["https://games.example.com"],
+    )
+    monkeypatch.setattr("gamatrix.config.get_settings", lambda: settings)
+
+    client = TestClient(app)
+    response = client.get(
+        "/healthz?probe=1",
+        headers={"host": "execute-api.example.amazonaws.com"},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 308
+    assert response.headers["location"] == "https://games.example.com/healthz?probe=1"
+
+
+def test_canonical_domain_allows_requests_on_canonical_host(monkeypatch):
+    settings = Settings(
+        local_dev=False,
+        jwt_secret="secret",
+        app_base_url="https://games.example.com",
+        webauthn_rp_id="games.example.com",
+        webauthn_origins=["https://games.example.com"],
+    )
+    monkeypatch.setattr("gamatrix.config.get_settings", lambda: settings)
+
+    client = TestClient(app)
+    response = client.get("/healthz", headers={"host": "games.example.com"})
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "ok"

--- a/tests/test_cdk_passkeys.py
+++ b/tests/test_cdk_passkeys.py
@@ -1,0 +1,81 @@
+"""CDK assertions for passkey storage and canonical RP configuration."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import aws_cdk as cdk
+import pytest
+from aws_cdk import assertions
+from aws_cdk import aws_route53 as route53
+
+CDK_DIR = Path(__file__).resolve().parents[1] / "infrastructure" / "cdk"
+sys.path.insert(0, str(CDK_DIR))
+
+from config import DeployConfig  # noqa: E402
+from gamatrix_stack import GamatrixStack  # noqa: E402
+
+
+def _stack(monkeypatch):
+    app = cdk.App()
+
+    def imported_zone(scope, construct_id, **kwargs):
+        return route53.HostedZone.from_hosted_zone_attributes(
+            scope,
+            construct_id,
+            hosted_zone_id="Z123456789",
+            zone_name=kwargs["domain_name"],
+        )
+
+    monkeypatch.setattr(route53.HostedZone, "from_lookup", imported_zone)
+    return GamatrixStack(
+        app,
+        "TestStack",
+        deploy_config=DeployConfig(
+            hosted_zone="example.com",
+            site_domain="games.example.com",
+        ),
+        env=cdk.Environment(account="123456789012", region="ca-central-1"),
+    )
+
+
+def test_stack_requires_stable_custom_domain():
+    with pytest.raises(ValueError, match="stable custom"):
+        GamatrixStack(cdk.App(), "NoDomain", deploy_config=DeployConfig())
+
+
+def test_stack_creates_passkey_tables_ttl_gsi_and_rp_environment(monkeypatch):
+    template = assertions.Template.from_stack(_stack(monkeypatch))
+    template.has_resource_properties(
+        "AWS::DynamoDB::Table",
+        {
+            "TableName": "gamatrix_passkeys",
+            "GlobalSecondaryIndexes": assertions.Match.array_with(
+                [assertions.Match.object_like({"IndexName": "user_handle-index"})]
+            ),
+        },
+    )
+    template.has_resource_properties(
+        "AWS::DynamoDB::Table",
+        {
+            "TableName": "gamatrix_auth_challenges",
+            "TimeToLiveSpecification": {
+                "AttributeName": "expires_at",
+                "Enabled": True,
+            },
+        },
+    )
+    template.has_resource_properties(
+        "AWS::Lambda::Function",
+        {
+            "Environment": {
+                "Variables": assertions.Match.object_like(
+                    {
+                        "WEBAUTHN_RP_ID": "games.example.com",
+                        "WEBAUTHN_ORIGINS": '["https://games.example.com"]',
+                    }
+                )
+            }
+        },
+    )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -10,7 +10,13 @@ from gamatrix.config import DEFAULT_JWT_SECRET, Settings, resolve_jwt_secret
 
 def test_production_rejects_default_jwt_secret():
     with pytest.raises(ValueError, match="JWT_SECRET"):
-        Settings(local_dev=False, jwt_secret=DEFAULT_JWT_SECRET, jwt_secret_name=None)
+        Settings(
+            local_dev=False,
+            jwt_secret=DEFAULT_JWT_SECRET,
+            jwt_secret_name=None,
+            webauthn_rp_id="games.example.com",
+            webauthn_origins=["https://games.example.com"],
+        )
 
 
 def test_local_dev_allows_default_jwt_secret():
@@ -23,6 +29,8 @@ def test_secret_name_satisfies_production_guard():
         local_dev=False,
         jwt_secret=DEFAULT_JWT_SECRET,
         jwt_secret_name="gamatrix/jwt-secret",
+        webauthn_rp_id="games.example.com",
+        webauthn_origins=["https://games.example.com"],
     )
     assert s.jwt_secret_name == "gamatrix/jwt-secret"
 
@@ -33,6 +41,16 @@ def test_resolve_jwt_secret_prefers_plain_value():
 
 
 def test_resolve_jwt_secret_reads_secrets_manager(monkeypatch):
-    s = Settings(local_dev=False, jwt_secret_name="gamatrix/jwt-secret")
+    s = Settings(
+        local_dev=False,
+        jwt_secret_name="gamatrix/jwt-secret",
+        webauthn_rp_id="games.example.com",
+        webauthn_origins=["https://games.example.com"],
+    )
     monkeypatch.setattr(config, "_fetch_secret_string", lambda name, region: "from-sm")
     assert resolve_jwt_secret(s) == "from-sm"
+
+
+def test_production_requires_canonical_https_passkey_domain():
+    with pytest.raises(ValueError, match="Production passkeys"):
+        Settings(local_dev=False, jwt_secret="secret")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -24,6 +24,11 @@ def test_local_dev_allows_default_jwt_secret():
     assert s.jwt_secret == DEFAULT_JWT_SECRET
 
 
+def test_local_dev_defaults_to_documented_local_base_url():
+    s = Settings(local_dev=True, jwt_secret=DEFAULT_JWT_SECRET, jwt_secret_name=None)
+    assert s.app_base_url == "http://localhost:8088"
+
+
 def test_secret_name_satisfies_production_guard():
     s = Settings(
         local_dev=False,

--- a/tests/test_passkeys.py
+++ b/tests/test_passkeys.py
@@ -1,0 +1,243 @@
+"""Black-box route tests and moto-backed persistence tests for passkeys."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+from fastapi.testclient import TestClient
+from webauthn.helpers import bytes_to_base64url
+from webauthn.helpers.structs import CredentialDeviceType
+
+from gamatrix.app import app
+from gamatrix.auth import passkeys, service
+from gamatrix.auth.dependencies import get_repo
+
+
+def _client(repo):
+    app.dependency_overrides[get_repo] = lambda: repo
+    client = TestClient(app)
+    yield client
+    app.dependency_overrides.clear()
+
+
+def _user(repo):
+    user = {
+        "email": "user@example.com",
+        "username": "User",
+        "password_hash": service.hash_password("password"),
+    }
+    repo.put_user(user)
+    return user
+
+
+def _login(client):
+    response = client.post(
+        "/auth/login",
+        data={"email": "user@example.com", "password": "password"},
+        follow_redirects=False,
+    )
+    assert response.status_code == 302
+
+
+def test_login_page_offers_explicit_and_conditional_passkeys(repo):
+    for client in _client(repo):
+        response = client.get("/auth/login")
+        assert response.status_code == 200
+        assert "Sign in with a passkey" in response.text
+        assert 'autocomplete="username webauthn"' in response.text
+        assert (
+            "isConditionalMediationAvailable" in client.get("/static/passkeys.js").text
+        )
+
+
+def test_registration_options_require_password_and_discoverable_uv(repo):
+    _user(repo)
+    for client in _client(repo):
+        _login(client)
+        denied = client.post(
+            "/auth/passkeys/register/options",
+            json={"password": "wrong", "friendly_name": "Laptop"},
+        )
+        assert denied.status_code == 403
+
+        response = client.post(
+            "/auth/passkeys/register/options",
+            json={"password": "password", "friendly_name": "Laptop"},
+        )
+        assert response.status_code == 200
+        options = response.json()["publicKey"]
+        assert options["authenticatorSelection"]["residentKey"] == "required"
+        assert options["authenticatorSelection"]["userVerification"] == "required"
+        assert options["attestation"] == "none"
+        assert repo.get_user("user@example.com")["webauthn_user_id"]
+
+
+def test_registration_route_stores_verified_passkey_and_rejects_replay(
+    repo, monkeypatch
+):
+    _user(repo)
+    verified = SimpleNamespace(
+        credential_id=b"credential-id",
+        credential_public_key=b"public-key",
+        sign_count=0,
+        credential_device_type=CredentialDeviceType.MULTI_DEVICE,
+        credential_backed_up=True,
+    )
+    monkeypatch.setattr(
+        passkeys, "verify_registration_response", lambda **kwargs: verified
+    )
+
+    for client in _client(repo):
+        _login(client)
+        options = client.post(
+            "/auth/passkeys/register/options",
+            json={"password": "password", "friendly_name": "Phone"},
+        ).json()
+        payload = {
+            "challenge_id": options["challenge_id"],
+            "credential": {
+                "id": bytes_to_base64url(b"credential-id"),
+                "response": {"transports": ["hybrid"]},
+            },
+        }
+        response = client.post("/auth/passkeys/register/verify", json=payload)
+        assert response.status_code == 200
+        assert response.json()["friendly_name"] == "Phone"
+        assert response.json()["backup_eligible"] is True
+        assert (
+            client.post("/auth/passkeys/register/verify", json=payload).status_code
+            == 400
+        )
+
+
+def test_passkey_login_issues_session_and_zero_counter_remains_usable(
+    repo, monkeypatch
+):
+    user = _user(repo)
+    handle = repo.ensure_webauthn_user_id(user["email"], "opaque-handle")
+    credential_id = bytes_to_base64url(b"credential-id")
+    repo.put_passkey(
+        {
+            "credential_id": credential_id,
+            "public_key": bytes_to_base64url(b"public-key"),
+            "user_handle": handle,
+            "email": user["email"],
+            "sign_count": 0,
+            "friendly_name": "Phone",
+        }
+    )
+    monkeypatch.setattr(
+        passkeys,
+        "verify_authentication_response",
+        lambda **kwargs: SimpleNamespace(
+            new_sign_count=0,
+            credential_backed_up=True,
+        ),
+    )
+
+    for client in _client(repo):
+        options = client.post("/auth/passkeys/authenticate/options").json()
+        response = client.post(
+            "/auth/passkeys/authenticate/verify",
+            json={
+                "challenge_id": options["challenge_id"],
+                "credential": {
+                    "id": credential_id,
+                    "response": {"userHandle": handle},
+                },
+            },
+        )
+        assert response.status_code == 200
+        assert response.json()["redirect"] == "/games"
+        assert service.COOKIE_NAME in response.cookies
+        assert repo.get_passkey(credential_id)["sign_count"] == 0
+
+
+def test_expired_challenge_and_unknown_credential_are_rejected(repo):
+    expired = {
+        "challenge_id": "expired",
+        "challenge": bytes_to_base64url(b"challenge"),
+        "ceremony": "authentication",
+        "expires_at": int(datetime.now(timezone.utc).timestamp()) - 1,
+    }
+    repo.put_auth_challenge(expired)
+    for client in _client(repo):
+        response = client.post(
+            "/auth/passkeys/authenticate/verify",
+            json={"challenge_id": "expired", "credential": {"id": "unknown"}},
+        )
+        assert response.status_code == 400
+
+        options = client.post("/auth/passkeys/authenticate/options").json()
+        response = client.post(
+            "/auth/passkeys/authenticate/verify",
+            json={
+                "challenge_id": options["challenge_id"],
+                "credential": {"id": "unknown"},
+            },
+        )
+        assert response.status_code == 400
+
+
+def test_listing_hides_key_material_and_deletion_requires_password(repo):
+    user = _user(repo)
+    handle = repo.ensure_webauthn_user_id(user["email"], "opaque-handle")
+    repo.put_passkey(
+        {
+            "credential_id": "credential",
+            "public_key": "secret-public-key",
+            "user_handle": handle,
+            "email": user["email"],
+            "sign_count": 0,
+            "friendly_name": "Laptop",
+        }
+    )
+    for client in _client(repo):
+        _login(client)
+        listed = client.get("/auth/passkeys/list")
+        assert listed.status_code == 200
+        assert listed.json()[0]["friendly_name"] == "Laptop"
+        assert "public_key" not in json.dumps(listed.json())
+
+        assert (
+            client.request(
+                "DELETE", "/auth/passkeys/credential", json={"password": "wrong"}
+            ).status_code
+            == 403
+        )
+        assert (
+            client.request(
+                "DELETE", "/auth/passkeys/credential", json={"password": "password"}
+            ).status_code
+            == 200
+        )
+        assert repo.get_passkey("credential") is None
+
+
+def test_challenge_consumption_is_atomic(repo):
+    repo.put_auth_challenge(
+        {
+            "challenge_id": "once",
+            "challenge": "value",
+            "ceremony": "authentication",
+            "expires_at": 9999999999,
+        }
+    )
+    assert repo.consume_auth_challenge("once") is True
+    assert repo.consume_auth_challenge("once") is False
+
+
+def test_nonzero_counter_update_rejects_stale_concurrent_write(repo):
+    repo.put_passkey(
+        {
+            "credential_id": "counter",
+            "user_handle": "handle",
+            "sign_count": 4,
+        }
+    )
+    assert repo.update_passkey_after_authentication("counter", 4, 5, False, "first")
+    assert not repo.update_passkey_after_authentication(
+        "counter", 4, 5, False, "second"
+    )

--- a/tests/test_passkeys.py
+++ b/tests/test_passkeys.py
@@ -5,12 +5,14 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from types import SimpleNamespace
 
+import pytest
 from fastapi.testclient import TestClient
+from fastapi import HTTPException
 from webauthn.helpers import bytes_to_base64url
 from webauthn.helpers.structs import CredentialDeviceType
 
 from gamatrix.app import app
-from gamatrix.auth import passkeys, service
+from gamatrix.auth import passkeys, routes, service
 from gamatrix.auth.dependencies import get_repo
 
 
@@ -245,6 +247,53 @@ def test_listing_hides_key_material_and_deletion_requires_password(repo):
             == 200
         )
         assert repo.get_passkey("credential") is None
+
+
+def test_delete_passkey_returns_explicit_404_without_registered_handle(repo):
+    _user(repo)
+    for client in _client(repo):
+        _login(client)
+        response = client.request(
+            "DELETE", "/auth/passkeys/missing", json={"password": "password"}
+        )
+        assert response.status_code == 404
+        assert (
+            response.json()["detail"] == "No passkeys are registered for this account."
+        )
+
+
+def test_delete_passkey_returns_explicit_404_for_missing_credential(repo):
+    user = _user(repo)
+    repo.ensure_webauthn_user_id(user["email"], "opaque-handle")
+    for client in _client(repo):
+        _login(client)
+        response = client.request(
+            "DELETE", "/auth/passkeys/missing", json={"password": "password"}
+        )
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Passkey not found for this account."
+
+
+def test_passkey_routes_preserve_original_error_cause(repo, monkeypatch):
+    _user(repo)
+
+    def fail(*args, **kwargs):
+        raise passkeys.PasskeyError("boom")
+
+    monkeypatch.setattr(passkeys, "registration_options", fail)
+
+    with pytest.raises(HTTPException) as exc_info:
+        routes.passkey_registration_options(
+            routes.RegistrationOptionsRequest(
+                password="password", friendly_name="Phone"
+            ),
+            user={"email": "user@example.com"},
+            repo=repo,
+        )
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail == "boom"
+    assert isinstance(exc_info.value.__cause__, passkeys.PasskeyError)
 
 
 def test_challenge_consumption_is_atomic(repo):

--- a/tests/test_passkeys.py
+++ b/tests/test_passkeys.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 from datetime import datetime, timezone
 from types import SimpleNamespace
 
@@ -50,6 +49,34 @@ def test_login_page_offers_explicit_and_conditional_passkeys(repo):
         assert (
             "isConditionalMediationAvailable" in client.get("/static/passkeys.js").text
         )
+
+
+def test_passkey_management_page_prefills_name_and_explains_password(repo):
+    _user(repo)
+    for client in _client(repo):
+        _login(client)
+        response = client.get("/auth/passkeys")
+        assert response.status_code == 200
+        assert 'value="Gamatrix passkey for User"' in response.text
+        assert (
+            "Required to verify your identity before adding a passkey" in response.text
+        )
+        assert "Waiting for passkey creation to complete..." in response.text
+
+
+def test_preferences_page_moves_manage_passkeys_into_page_body(repo):
+    _user(repo)
+    for client in _client(repo):
+        _login(client)
+        response = client.get("/preferences")
+        assert response.status_code == 200
+        assert (
+            '<div class="right"><a href="/games">Back to games</a></div>'
+            in response.text
+        )
+        assert "Manage passkeys</a>" not in response.text
+        assert "Manage passkeys</button>" in response.text
+        assert "Add, review, or remove passkeys for this account." in response.text
 
 
 def test_registration_options_require_password_and_discoverable_uv(repo):
@@ -198,8 +225,12 @@ def test_listing_hides_key_material_and_deletion_requires_password(repo):
         _login(client)
         listed = client.get("/auth/passkeys/list")
         assert listed.status_code == 200
-        assert listed.json()[0]["friendly_name"] == "Laptop"
-        assert "public_key" not in json.dumps(listed.json())
+        assert "Laptop" in listed.text
+        assert "Back to preferences" in listed.text
+        assert "Add a passkey" not in listed.text
+        assert "Current password" not in listed.text
+        assert "public_key" not in listed.text
+        assert "secret-public-key" not in listed.text
 
         assert (
             client.request(

--- a/uv.lock
+++ b/uv.lock
@@ -29,6 +29,15 @@ wheels = [
 ]
 
 [[package]]
+name = "asn1crypto"
+version = "1.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/de/cf/d547feed25b5244fcb9392e288ff9fdc3280b10260362fc45d37a798a6ee/asn1crypto-1.5.1.tar.gz", hash = "sha256:13ae38502be632115abf8a24cbe5f4da52e3b5231990aff31123c805306ccb9c", size = 121080, upload-time = "2022-03-15T14:46:52.889Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c9/7f/09065fd9e27da0eda08b4d6897f1c13535066174cc023af248fc2a8d5e5a/asn1crypto-1.5.1-py2.py3-none-any.whl", hash = "sha256:db4e40728b728508912cbb3d44f19ce188f218e9eba635821bb4b68564f8fd67", size = 105045, upload-time = "2022-03-15T14:46:51.055Z" },
+]
+
+[[package]]
 name = "ast-serialize"
 version = "0.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -306,6 +315,46 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a0/ec/ba18945e7d6e55a58364d9fb2e46049c1c2998b3d805f19b703f14e81057/cattrs-26.1.0.tar.gz", hash = "sha256:fa239e0f0ec0715ba34852ce813986dfed1e12117e209b816ab87401271cdd40", size = 495672, upload-time = "2026-02-18T22:15:19.406Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/80/56/60547f7801b97c67e97491dc3d9ade9fbccbd0325058fd3dfcb2f5d98d90/cattrs-26.1.0-py3-none-any.whl", hash = "sha256:d1e0804c42639494d469d08d4f26d6b9de9b8ab26b446db7b5f8c2e97f7c3096", size = 73054, upload-time = "2026-02-18T22:15:17.958Z" },
+]
+
+[[package]]
+name = "cbor2"
+version = "6.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/75/af/473c241e41c142ea06ebef8d1f660fa6ff928fb97210e7bec8ee5974f8cd/cbor2-6.1.2.tar.gz", hash = "sha256:6b43037a66947dee5af0abb1a4c3a13b3abac5a4a3f32f9771efbbcd030fd909", size = 86760, upload-time = "2026-06-02T19:01:29.333Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/0c/a857b6ca032282b564cf25de18ad92fe0614e8b3fa3422eb10e32a873939/cbor2-6.1.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:92b158d3ff9d9dce70eeb09786a6e518e3cb0ecb927fd23e9a0f7fc4b175c01a", size = 409592, upload-time = "2026-06-02T19:00:44.556Z" },
+    { url = "https://files.pythonhosted.org/packages/29/db/e0518153b3228159d9373f3b5785d7ea2d68898e27ee1bce7d03f0b5f7aa/cbor2-6.1.2-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:d29a11044b07048e19f39a87fe8fea7ea865eb0ace50dc4c29513d52d40e2ddf", size = 454598, upload-time = "2026-06-02T19:00:45.784Z" },
+    { url = "https://files.pythonhosted.org/packages/29/67/62127b22edc6011ba55b76a28ab7c2219a45d01871a8199532e0978b26d1/cbor2-6.1.2-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:a106f174eda34d8937a621c7f3e6044586cb209170cdc8da0ffbea89d1d6e385", size = 467380, upload-time = "2026-06-02T19:00:47.196Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/95/7992d8ec904c116ad547abb4960cc3fde695d5853c66596b1465d14d2f7b/cbor2-6.1.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2ea16a25cc457a92879ff7a36cc50b587bddba09d8176bf1a94803eec5aa27eb", size = 521672, upload-time = "2026-06-02T19:00:48.656Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/cf/80cc4be132a523f0c92fb4c71813577bb393abea9e27990ca74605e0e930/cbor2-6.1.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2652a94224980d47f2a3866dd35b1afe532ecdfaf91f8cfcec39a026c457a844", size = 534402, upload-time = "2026-06-02T19:00:50.064Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/ea/99e466d8bef61a0775a1d8538ae6c9d95f4533fadc01f8f7814cb7ab80ad/cbor2-6.1.2-cp312-cp312-win32.whl", hash = "sha256:618666292900487db4a5abcade3150105c9c9fdd22576e6ff297c9a72eef0c6a", size = 283225, upload-time = "2026-06-02T19:00:51.406Z" },
+    { url = "https://files.pythonhosted.org/packages/14/13/e6a677bdc499e43049006cb54fe605b0f7aef621402d31354cc42ef293c9/cbor2-6.1.2-cp312-cp312-win_amd64.whl", hash = "sha256:c61c0b2e2cee64497e6c62d1976bc212f62ac0cd2b5b903613610d79b8b06b60", size = 300844, upload-time = "2026-06-02T19:00:52.628Z" },
+    { url = "https://files.pythonhosted.org/packages/77/4a/08bd8461f8e2e1ce1de5ae2768f2b7ca39a090e3156c1ee0d9b5fd86e70d/cbor2-6.1.2-cp312-cp312-win_arm64.whl", hash = "sha256:c871e7266ddc545b258e6f8e5300396985dc485d7ccf8bb4777385782f302153", size = 289040, upload-time = "2026-06-02T19:00:53.971Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/dc/bc045c8f36317e4e5f7a60d94b36833139909fc32e3a65f44bc61a36def0/cbor2-6.1.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f1aa38c422d87ea61849b2a823b10b64053fb4da8763f19ac78ea9a69d682b2a", size = 408846, upload-time = "2026-06-02T19:00:55.476Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/36/d66f5f0dd98ecbdcfc7da1fbd423f7b3782a27719f0062a560476f00b334/cbor2-6.1.2-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:ff7d0bd8ff432832338a8d2430aee34f8a082342480ff537c0ba90e2b8ff7894", size = 454624, upload-time = "2026-06-02T19:00:56.744Z" },
+    { url = "https://files.pythonhosted.org/packages/38/6b/4884b9cf03db14dc5007825d5d1bf8678a75c49d4268d8e0c1c6e9580104/cbor2-6.1.2-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:c1eedf3290d88a5f663bd8b4b8f0f0e2103d0594c293fa5f4e62e53100972309", size = 466585, upload-time = "2026-06-02T19:00:58.209Z" },
+    { url = "https://files.pythonhosted.org/packages/50/f6/36a15beb3915f56a79d6e9213c6d40c0f5cb90cd3462923f555d78068847/cbor2-6.1.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:3049b04bddf9a5a2d0e5bb25dccdaf4552fcaf607b404e249d4f78f010fcc7d0", size = 521678, upload-time = "2026-06-02T19:00:59.524Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/3f/e899313371ebeb7a191d751de97ccd8242abc24bbc9d8e2c58e04475cfb0/cbor2-6.1.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:96eb687a62040401668f06a85de8f47361ef44574de1493899e0ec678109fc04", size = 534044, upload-time = "2026-06-02T19:01:00.875Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/5e/1a872acdeb1ab9a884ec3460f73a43e02154dc20d8ccb627bbd60f4c0ea1/cbor2-6.1.2-cp313-cp313-win32.whl", hash = "sha256:03440b505882280023db1fedcee6844804e9968bb50f9eb4ff12aaf27777fcfe", size = 282328, upload-time = "2026-06-02T19:01:02.347Z" },
+    { url = "https://files.pythonhosted.org/packages/70/79/29721bc15d38889e7bec214ede2346ee15970bedcc5e6ce1fa30f21e9a4e/cbor2-6.1.2-cp313-cp313-win_amd64.whl", hash = "sha256:d2c8da2c0f821827dcc9eb59a5c9351791a8aa3b389a2ea7ca64c4f97bcb94cf", size = 300313, upload-time = "2026-06-02T19:01:03.69Z" },
+    { url = "https://files.pythonhosted.org/packages/07/98/a13b424fb2f14fe332b57f71f479953b2f291a051f797d42ddab9fcd2027/cbor2-6.1.2-cp313-cp313-win_arm64.whl", hash = "sha256:8e1478d3b980ddfcaf56e27cecbfe13057e0f67d5e8240fe8a398815acb9c4bf", size = 288725, upload-time = "2026-06-02T19:01:04.933Z" },
+    { url = "https://files.pythonhosted.org/packages/62/72/949bdc7422acd868a2355ae032561a104973fb5de284b36a237b85780dc9/cbor2-6.1.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:b0b65314a0b18c47651e17792447171a858dd77e3f161c451ad850d63f8718a9", size = 407436, upload-time = "2026-06-02T19:01:06.259Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/bd/5969f9263102d1c15aa370b39802e4a87b1d1703fdb51588daf38b5fbe7e/cbor2-6.1.2-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:8904deb2849bae40cea970e114398a19da371e1048ae1409e64f167a1205daf6", size = 453507, upload-time = "2026-06-02T19:01:07.795Z" },
+    { url = "https://files.pythonhosted.org/packages/93/a5/227b785692a8374e3dbdf1fe76d1a9af48239855abd68a4111a1458fd81b/cbor2-6.1.2-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:b29d58d8ce00535354d873df170a3e9f0f0a02af65d12102d2552e2129c65dc8", size = 464875, upload-time = "2026-06-02T19:01:09.222Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/48/a06527c3fbed4c32816abba4540e432fe9cd7e739a37fef0f205bd0f1e44/cbor2-6.1.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:27be1cc0abc42f154a48a315c92feb2bfb50397e51c70860460438ea172198a5", size = 519940, upload-time = "2026-06-02T19:01:10.795Z" },
+    { url = "https://files.pythonhosted.org/packages/31/1b/0e3f0dac7140d4b94ffbcef765fa4cce0caa1d942060101149de998fa7be/cbor2-6.1.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:b8d87fb8a33ff1971cb01511e74b044767cbba1ba536d3dc0b0c48f0d1b62237", size = 532612, upload-time = "2026-06-02T19:01:12.363Z" },
+    { url = "https://files.pythonhosted.org/packages/35/2f/5af245e7667b65c6e4a714bb5d89c84de5573b857eba9137533d54bc2e4f/cbor2-6.1.2-cp314-cp314-win32.whl", hash = "sha256:72ba0ea913ca1a8d916867f1b7d414f140982d2873e5d92f8f51de437e08979e", size = 285886, upload-time = "2026-06-02T19:01:13.658Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/0a/6303f3e19730450c5a82b97cd2c0ed54855f9108502041305b4c641116cd/cbor2-6.1.2-cp314-cp314-win_amd64.whl", hash = "sha256:c02b7d94fe9914798a346a2f089f0f7f85be71d120d40080916d131fa0bd0442", size = 308808, upload-time = "2026-06-02T19:01:14.944Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/61/48f9c5545223dad9d2ea2061a76da739b4047a461297b621fc80ce0f65c0/cbor2-6.1.2-cp314-cp314-win_arm64.whl", hash = "sha256:2af1309865000c401755fd4fdd5550f74ac34c3f79eb7db15f3956714769a5a9", size = 299522, upload-time = "2026-06-02T19:01:16.393Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/2b/efcc6578b4e6142fb8ec9212c0dee5030345db2092f26aa960236067e717/cbor2-6.1.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:9f26e08dd78ee77d103065543a65cfb838948fa8735180ad4d81d939950a1420", size = 402925, upload-time = "2026-06-02T19:01:17.979Z" },
+    { url = "https://files.pythonhosted.org/packages/58/f6/58c86aa6246b3e7de473d8ff79ac8cc986e95cafe208899a70d6916012d7/cbor2-6.1.2-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:596e238f24bf9ede11a1ad08d2115fe78105ed6dda42ce1dd35872e7e91974fd", size = 446201, upload-time = "2026-06-02T19:01:19.481Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/12/3b90820583e9860e35cb5e91f3b2cd2ab1bbdf1c57fc63aa572952f5f75f/cbor2-6.1.2-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:08a62f69fe0f0ee1428d901423853b56bb5c775430f798401f8fac4b9affdecc", size = 460193, upload-time = "2026-06-02T19:01:20.876Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/88/c1e841ffb39a8e7163d7d432f7ea0e59b812c5134a449c75b6b8eb8aad08/cbor2-6.1.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:6ca0080e4d8ab0d67c0518ac995d03151a1274b5c295c9e619fb6057c91ae49e", size = 511446, upload-time = "2026-06-02T19:01:22.18Z" },
+    { url = "https://files.pythonhosted.org/packages/db/0a/f1ede587a388f127b9fc3d8ecb2f5d948654fed9fc7698f8b05fd90986bf/cbor2-6.1.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:b44eb2f3ea1c8d9cb3e39c345204ec4d9489f8149b78eb5e058b13b14a8c7b07", size = 527683, upload-time = "2026-06-02T19:01:23.639Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/89/e3210ea45855a8d6173821f712a71a90d23dea0c134c4017c6f666a04fdf/cbor2-6.1.2-cp314-cp314t-win32.whl", hash = "sha256:f93179b4b1ba958b5c37b56969b8f07b4fcf44a83319f47559c59f28a1c564a4", size = 280419, upload-time = "2026-06-02T19:01:25.365Z" },
+    { url = "https://files.pythonhosted.org/packages/96/84/b555de26cc01108a72ed1df8eb7ca1d63495a3727045f0f93318dc5f99a8/cbor2-6.1.2-cp314-cp314t-win_amd64.whl", hash = "sha256:3c6c3d6598c268abf7068ae75b23b19f708e7a4aa294341b356deb65cb2664f1", size = 302514, upload-time = "2026-06-02T19:01:26.782Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/6e/5556939414c0d2bffed7c7a53cf2b32181b55a795944d19835d513a7bc88/cbor2-6.1.2-cp314-cp314t-win_arm64.whl", hash = "sha256:8c2202fd1906f978bff3f97b21351815753dd9a8fcf4612a5113b6b257089059", size = 290058, upload-time = "2026-06-02T19:01:28.077Z" },
 ]
 
 [[package]]
@@ -691,6 +740,7 @@ dependencies = [
     { name = "python-multipart" },
     { name = "rapidfuzz" },
     { name = "uvicorn", extra = ["standard"] },
+    { name = "webauthn" },
 ]
 
 [package.optional-dependencies]
@@ -743,6 +793,7 @@ requires-dist = [
     { name = "rapidfuzz", specifier = "==3.11.0" },
     { name = "types-python-jose", marker = "extra == 'dev'" },
     { name = "uvicorn", extras = ["standard"], specifier = "==0.34.0" },
+    { name = "webauthn", specifier = "==2.7.0" },
 ]
 provides-extras = ["dev", "ci", "cdk"]
 
@@ -1349,6 +1400,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pyopenssl"
+version = "26.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1a/51/27a5ad5f939d08f690a326ef9582cda7140555180db71695f6fb747d6a36/pyopenssl-26.2.0.tar.gz", hash = "sha256:8c6fcecd1183a7fc897548dfe388b0cdb7f37e018200d8409cf33959dbe35387", size = 182195, upload-time = "2026-05-04T23:06:09.72Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/b8/a0e2790ae249d6f38c9f66de7a211621a7ab2650217bcd04e1262f578a56/pyopenssl-26.2.0-py3-none-any.whl", hash = "sha256:4f9d971bc5298b8bc1fab282803da04bf000c755d4ad9d99b52de2569ca19a70", size = 55823, upload-time = "2026-05-04T23:06:08.395Z" },
+]
+
+[[package]]
 name = "pyproject-hooks"
 version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1861,6 +1925,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/56/fe/cb8ef3d6f929d14158fdaaad9925985b7310abc9384dcd4d82dd0016fb59/watchfiles-1.2.0-cp315-cp315-manylinux_2_31_riscv64.whl", hash = "sha256:cee9d5efd929efdac5f7e58f72b3376f676b64050a91c5b99a7094c5b2317488", size = 465096, upload-time = "2026-05-18T04:31:30.384Z" },
     { url = "https://files.pythonhosted.org/packages/25/91/80908e835e100527a9267147b08c0eee1fa6ab0ffec15edc04d1d44885f7/watchfiles-1.2.0-cp315-cp315-musllinux_1_1_aarch64.whl", hash = "sha256:b718bf356bbc15e559bd8ef41782b573b8ae0e3f177ab244b440568d7ea02cfb", size = 630638, upload-time = "2026-05-18T04:30:49.89Z" },
     { url = "https://files.pythonhosted.org/packages/46/4b/95ab2f256bb4af3cb2eb23b9317bda984ee6e0f11733a5c004a6c95b06e3/watchfiles-1.2.0-cp315-cp315-musllinux_1_1_x86_64.whl", hash = "sha256:922c0e019fe68b3ae392965a766b02a71ba1168c932cebc3733cd52c5fe5b377", size = 657684, upload-time = "2026-05-18T04:31:32.027Z" },
+]
+
+[[package]]
+name = "webauthn"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asn1crypto" },
+    { name = "cbor2" },
+    { name = "cryptography" },
+    { name = "pyopenssl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a4/f0/e1036df8842782a2947e5f41e76a4accb92e3dba972dba882321ebe15af0/webauthn-2.7.0.tar.gz", hash = "sha256:3c45c25e75a7d7d419220ccd10b8b899984de8012732e10d898f0a8f8c480575", size = 123770, upload-time = "2025-09-04T23:19:21.602Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/b1/3f380d02552f1d75d3db789f761a1ee0dafd6181ebc07dd4b9ded61225a4/webauthn-2.7.0-py3-none-any.whl", hash = "sha256:2ecfee7959b09ebeaaffee9f8982ecdbbdc369a11766d20d4bc0637b36e235b7", size = 71311, upload-time = "2025-09-04T23:19:20.269Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Add passkey logins for gamatrix. Let's leave passwords in the dust.

- Added end-to-end passkey support so users can sign in with a passkey and manage their passkeys from within Gamatrix.
- Built the supporting backend, storage, and infrastructure needed to safely register, verify, store, and use passkeys in both local and deployed environments.
- Polished the experience with security hardening, clearer UX, stronger documentation, and broader automated test coverage.

## How

- Added passkey registration and sign-in flows to the authentication system, including browser-facing routes, WebAuthn ceremony handling, and account-level passkey management.
 - Introduced persistent storage and challenge tracking for passkeys, plus the required application and infrastructure configuration so the feature works with the app’s existing FastAPI, DynamoDB, and deployment setup.
 - Updated the UI so users can start passkey sign-in from the login page, manage passkeys from preferences, get clearer guidance during setup, and land on a simpler confirmation view after adding a passkey.
 - Strengthened the backend validation to better prevent replayed sign-in attempts, added the missing documentation expected by the repo conventions, and expanded tests to cover the new auth, management, and infrastructure behavior.

## Checklist

- [x] PR checks pass
- [x] Tests added/updated for the change
- [x] Version label applied if this is more than a patch (see below)
