### PR TITLE
Fix DB updated tooltip always showing 'never'

### DIFF
--- a/src/gamatrix/gogdb/ingest.py
+++ b/src/gamatrix/gogdb/ingest.py
@@ -35,6 +35,10 @@ def ingest_db_file(
     entries = [{**e, "db_updated_at": timestamp} for e in parsed.entries]
     repo.replace_user_library(parsed.user_id, entries)
 
+    user = repo.get_user_by_user_id(parsed.user_id)
+    if user:
+        repo.update_user(user["email"], {"db_updated_at": timestamp})
+
     # Upsert game stubs; collect release keys that still need IGDB enrichment.
     to_enrich: list[str] = []
     for stub in parsed.games:

--- a/tests/test_gogdb.py
+++ b/tests/test_gogdb.py
@@ -189,3 +189,17 @@ def test_ingest_same_db_twice_with_duplicate_parser_rows_is_idempotent(
         "xboxone_200",
     }
     assert len(library) == 3
+
+
+def test_ingest_writes_db_updated_at_to_user_record(gog_db, repo, settings):
+    repo.put_user(
+        {"email": "tester@example.com", "user_id": "12345", "username": "tester"}
+    )
+    queue = EnrichmentQueue(settings=settings)
+
+    ingest_db_file(gog_db, repo, queue)
+
+    user = repo.get_user("tester@example.com")
+    assert user is not None
+    assert user.get("db_updated_at") is not None
+    assert user["db_updated_at"] != "never"


### PR DESCRIPTION
## What

Fix for the DB updated-on mouse-over

## How

The ingest path stamped db_updated_at on each user_libraries row but never on the user record itself, so the main-page tooltip always fell back to 'never'. Now writes the same timestamp to the users table via get_user_by_user_id + update_user after each successful ingest.

## Checklist

- [x] PR checks pass
- [x] Tests added/updated for the change
- [x] Version label applied if this is more than a patch (see below)

