### PR TITLE
Fix "Refresh missing IGDB" silently skipping all games

### DIFF
--- a/src/gamatrix/games/routes.py
+++ b/src/gamatrix/games/routes.py
@@ -193,11 +193,16 @@ def refresh_missing(
     repo: Repository = Depends(get_repo),
 ):
     """Re-enrich games IGDB didn't find last time."""
-    release_keys = [
-        g["release_key"]
+    missing = [
+        g
         for g in repo.scan_all_games()
         if g.get("enrichment_status") == ENRICHMENT_NOT_FOUND
     ]
+    # The enricher only touches games that are unenriched or pending, so flip
+    # these from not_found to pending or they'd be skipped (see #134).
+    for game in missing:
+        repo.put_game({**game, "enrichment_status": ENRICHMENT_PENDING})
+    release_keys = [g["release_key"] for g in missing]
     job_id = create_enrichment_job(repo, get_queue(), release_keys)
     return templates.TemplateResponse(
         request,

--- a/tests/test_refresh_igdb.py
+++ b/tests/test_refresh_igdb.py
@@ -1,0 +1,78 @@
+"""Regression tests for the IGDB refresh routes.
+
+`Refresh missing IGDB` re-enriches games IGDB didn't find last time. The
+enricher only processes games whose status is unset or `pending` (#134), so the
+route must flip the targeted `not_found` games to `pending` first — otherwise
+every game it queues is silently skipped and the button does nothing.
+"""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from gamatrix.app import app
+from gamatrix.auth.dependencies import get_repo, require_admin
+from gamatrix.constants import (
+    ENRICHMENT_DONE,
+    ENRICHMENT_NOT_FOUND,
+    ENRICHMENT_PENDING,
+)
+from gamatrix.helpers import now_iso
+
+
+def _client(repo):
+    app.dependency_overrides[get_repo] = lambda: repo
+    app.dependency_overrides[require_admin] = lambda: {
+        "email": "admin@example.com",
+        "is_admin": True,
+    }
+    client = TestClient(app)
+    yield client
+    app.dependency_overrides.clear()
+
+
+def _game(repo, rk, status):
+    repo.put_game(
+        {
+            "release_key": rk,
+            "title": rk,
+            "igdb_key": rk,
+            "platform": rk.split("_")[0],
+            "enrichment_status": status,
+            "enriched_at": now_iso(),
+        }
+    )
+
+
+def test_refresh_missing_marks_not_found_games_pending(repo):
+    _game(repo, "steam_1", ENRICHMENT_NOT_FOUND)
+    _game(repo, "gog_2", ENRICHMENT_NOT_FOUND)
+    _game(repo, "steam_3", ENRICHMENT_DONE)
+    for client in _client(repo):
+        response = client.post("/games/refresh-igdb")
+        assert response.status_code == 200
+
+    # The not_found games are flipped to pending so the enricher will pick them
+    # up; the already-enriched game is left untouched.
+    assert repo.get_game("steam_1")["enrichment_status"] == ENRICHMENT_PENDING
+    assert repo.get_game("gog_2")["enrichment_status"] == ENRICHMENT_PENDING
+    assert repo.get_game("steam_3")["enrichment_status"] == ENRICHMENT_DONE
+
+
+def test_refresh_missing_queues_only_not_found_games(repo):
+    _game(repo, "steam_1", ENRICHMENT_NOT_FOUND)
+    _game(repo, "steam_3", ENRICHMENT_DONE)
+    for client in _client(repo):
+        assert client.post("/games/refresh-igdb").status_code == 200
+
+    job = repo.get_active_job()
+    assert job is not None
+    assert job["release_keys"] == ["steam_1"]
+
+
+def test_refresh_missing_with_nothing_to_do_creates_no_job(repo):
+    _game(repo, "steam_3", ENRICHMENT_DONE)
+    for client in _client(repo):
+        assert client.post("/games/refresh-igdb").status_code == 200
+
+    assert repo.get_active_job() is None


### PR DESCRIPTION
## What

The **Refresh missing IGDB** button currently updates **no titles**. This fixes it.

## Why

`refresh_missing` (`games/routes.py`) collects games with `enrichment_status == "not_found"` and enqueues an enrichment job for them — but it never changes their stored status.

Meanwhile the enricher skips any game whose status isn't `None` or `"pending"`:

```python
if game.get("enrichment_status") not in (None, ENRICHMENT_PENDING):
    continue
```

That guard was added in #134 ("Fix igdb retries") to stop redelivered/concurrent jobs from re-enriching already-`done` games — but it also means every `not_found` game queued by `refresh_missing` is filtered straight back out. `refresh_all` works because it explicitly marks each game `pending` before enqueuing; `refresh_missing` was never updated to match, so it regressed silently.

## How

- Flip the targeted `not_found` games to `pending` before enqueuing, reusing the records already returned by `scan_all_games()` (no extra reads), mirroring `refresh_all`.
- Add `tests/test_refresh_igdb.py` covering the status flip, that only `not_found` games are queued, and the no-op case. The status-flip test fails on `master` and passes with this change.

## Checklist

- [x] PR checks pass (local: `pytest` 82 passed, `black`, `flake8`, `mypy` all clean)
- [x] Tests added for the change
- [ ] Version label — patch (bug fix), no label needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)