### PR TITLE
Freeze the results heading row while scrolling

### DIFF
--- a/src/gamatrix/static/style.css
+++ b/src/gamatrix/static/style.css
@@ -78,6 +78,15 @@ table.results thead th {
   background-color: var(--accent);
   cursor: pointer;
   user-select: none;
+  /* Keep the heading row visible while scrolling the results. The page itself
+     scrolls (the topbar isn't fixed), so stick to the viewport top. */
+  position: sticky;
+  top: 0;
+  /* Paint above the colored owned/unowned cells that scroll underneath. */
+  z-index: 2;
+  /* border-collapse drops a sticky cell's own borders, so redraw the top and
+     bottom rules as an inset shadow that stays put. */
+  box-shadow: inset 0 1px 0 black, inset 0 -1px 0 black;
 }
 table.results thead th:hover { filter: brightness(1.05); }
 table.results tbody tr:nth-child(odd) { background-color: var(--row-a); }


### PR DESCRIPTION
## What

Pin the results table's heading row so the column headers (and their sort controls) stay visible when scrolling down a long list of games.

<img width="820" height="720" alt="sticky-check" src="https://github.com/user-attachments/assets/bbe1f58b-5ff2-4211-bc57-67239703b812" />

## Why

The results table often runs much taller than the viewport. Once you scroll past the first screenful, the headers scroll away — you lose track of which column is which, and the clickable sort headers go off-screen.

## How

CSS-only change to `table.results thead th`:

- `position: sticky; top: 0` pins the heading row to the top of the viewport. The page itself scrolls (the topbar isn't fixed), so `top: 0` is the right anchor.
- `z-index: 2` so the opaque header paints over the colored owned/unowned cells that scroll underneath it.
- `box-shadow: inset 0 1px 0 black, inset 0 -1px 0 black` to redraw the top/bottom border rules — `border-collapse: collapse` drops a sticky cell's own borders, so without this the header would lose its separator lines while pinned.

## Verification

Rendered the real `style.css` against a tall sample results table in headless Chrome and scrolled the rows. Confirmed the heading row stays pinned at the top with its accent background, paints over the scrolling colored owned/unowned cells (z-index), and keeps its top/bottom border lines intact (box-shadow). CSS-only — no Python touched, so the test suite is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)