### PR TITLE
Make the sticky results header work in Firefox

### DIFF
--- a/src/gamatrix/static/style.css
+++ b/src/gamatrix/static/style.css
@@ -65,11 +65,18 @@ button.secondary { background: #777; color: white; }
 
 /* Results table */
 table.results {
-  border-collapse: collapse;
+  /* Firefox can't position:sticky a cell inside a border-collapse:collapse
+     table (bugzilla 1488080), so use separate borders and rebuild the 1px grid
+     from one-sided cell borders. The header below then keeps its own borders
+     when pinned, which collapse would have dropped. */
+  border-collapse: separate;
+  border-spacing: 0;
   width: 100%;
+  border-left: 1px solid black;
 }
 table.results th, table.results td {
-  border: 1px solid black;
+  border-right: 1px solid black;
+  border-bottom: 1px solid black;
   padding: 4px 8px;
   color: var(--row-text);
 }
@@ -78,15 +85,13 @@ table.results thead th {
   background-color: var(--accent);
   cursor: pointer;
   user-select: none;
+  border-top: 1px solid black;
   /* Keep the heading row visible while scrolling the results. The page itself
      scrolls (the topbar isn't fixed), so stick to the viewport top. */
   position: sticky;
   top: 0;
   /* Paint above the colored owned/unowned cells that scroll underneath. */
   z-index: 2;
-  /* border-collapse drops a sticky cell's own borders, so redraw the top and
-     bottom rules as an inset shadow that stays put. */
-  box-shadow: inset 0 1px 0 black, inset 0 -1px 0 black;
 }
 table.results thead th:hover { filter: brightness(1.05); }
 table.results tbody tr:nth-child(odd) { background-color: var(--row-a); }


### PR DESCRIPTION
## What

Follow-up to #156. The frozen results heading row works in Chrome but **not Firefox** — in Firefox the header still scrolls away. This makes it work there too.

## Why

Firefox has a long-standing bug ([Bugzilla 1488080](https://bugzilla.mozilla.org/show_bug.cgi?id=1488080)): `position: sticky` on a table cell does **nothing** when the table uses `border-collapse: collapse`. Our results table used collapsed borders, so #156's `position: sticky` on `thead th` was silently ignored by Firefox while Chrome honored it.

## How

Switch the table off collapsed borders and rebuild the same 1px grid from one-sided cell borders:

- `border-collapse: separate; border-spacing: 0` on the table (the part Firefox needs).
- Borders moved to single sides so they don't double up: `border-right` + `border-bottom` on every cell, `border-left` on the table, and `border-top` on the header cells.
- Dropped the inset `box-shadow` from #156 — it existed only to redraw borders that `collapse` stripped from a sticky cell. With separate borders the header keeps its own borders when pinned, so it's unnecessary.

The rendered grid is identical to before.

## Verification

- **Chrome:** rendered the updated `style.css` against a tall sample results table in headless Chrome and scrolled it — the grid is pixel-identical to the collapsed version and the header still pins correctly (sort controls + borders intact).
- **Firefox:** I couldn't run headless Firefox in my sandbox (snap confinement kills it), so I wasn't able to screenshot-confirm there. The change targets exactly the documented `border-collapse` bug, but a quick manual check on real Firefox after deploy would be worth it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)