### PR TITLE
Cache-bust the stylesheet so CSS changes show up after deploy

### DIFF
--- a/src/gamatrix/templates/base.html.jinja
+++ b/src/gamatrix/templates/base.html.jinja
@@ -4,7 +4,9 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{% block title %}gamatrix{% endblock %}</title>
-    <link rel="stylesheet" href="/static/style.css">
+    {# Version query busts the browser cache on each deploy so CSS changes
+       (e.g. the sticky results header) aren't masked by a stale stylesheet. #}
+    <link rel="stylesheet" href="/static/style.css?v={{ version }}">
     <script src="https://unpkg.com/htmx.org@2.0.4"></script>
 </head>
 <body>

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -1,0 +1,14 @@
+"""Template-level guards for the shared base layout."""
+
+from __future__ import annotations
+
+import re
+
+from gamatrix.templating import templates
+
+
+def test_stylesheet_link_is_cache_busted():
+    """The stylesheet must carry a version query so a deploy's CSS changes
+    aren't masked by a browser serving a stale /static/style.css."""
+    html = templates.env.get_template("base.html.jinja").render()
+    assert re.search(r'href="/static/style\.css\?v=[^"]+"', html)


### PR DESCRIPTION
## What

Append the app version to the stylesheet URL (`/static/style.css?v=<version>`) so browsers fetch fresh CSS after every deploy.

## Why — the real cause of the "Firefox sticky header" issue

The frozen results header (#156) worked in Chrome/Edge but looked broken in Firefox, and #157 didn't change that. It turns out **the CSS was correct all along** — I drove current Firefox (151.0.3) with Selenium against the real rendered page and the header pins correctly (`getBoundingClientRect().top == 0` after scrolling) with both the #156 and #157 stylesheets.

The actual problem was a **stale cached stylesheet**: Firefox was still serving the pre-#156 `/static/style.css` (no sticky rule), so the header never stuck there, while Chrome/Edge had a fresh copy. A hard reload (Ctrl+Shift+R) in Firefox fixed it — confirming caching, not CSS.

The stylesheet was linked with no cache-busting, so any browser can hold an old copy across deploys and mask future CSS changes too.

## How

- `base.html.jinja`: `href="/static/style.css?v={{ version }}"`. The `version` global is the setuptools_scm package version, which bumps on every merge to master, so each deploy gets a new URL and browsers refetch.
- The query is only a browser cache key — `StaticFiles` ignores it and serves the file normally (verified: `GET /static/style.css?v=9.9.9` → 200 with the real CSS).
- Added `tests/test_templates.py` asserting the stylesheet link is versioned.

## Notes

- #156 and #157 were both CSS-correct; no revert needed. #157's switch to `border-collapse: separate` renders identically and is arguably more robust, so it's fine to leave.
- Verification: `pytest tests/test_templates.py` passes; `black`/`flake8` clean. Selenium repro of the header pinning in Firefox done locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)