### PR TITLE
Filter Game Pass titles GOG flags as owned (#120)

### DIFF
--- a/src/gamatrix/gogdb/parser.py
+++ b/src/gamatrix/gogdb/parser.py
@@ -61,21 +61,34 @@ class GogDBParser:
         ).fetchone()[0]
 
     def get_subscription_release_keys(self) -> set[str]:
-        """Release keys present only via a subscription (issue #120).
+        """Release keys available via a subscription, not owned (issue #120).
 
         Xbox Game Pass titles stay in ProductPurchaseDates after they leave the
-        subscription, so v1 reported them as owned forever. LicensedReleases
-        flags genuine ownership: isOwned = 0 means the title is only available
-        through a subscription (verified: all such rows are Xbox Game Pass).
+        subscription, so v1 reported them as owned forever. Two GOG tables flag
+        them, and neither is sufficient on its own:
+
+        - LicensedReleases.isOwned = 0 marks most Game Pass titles as not owned.
+        - But GOG leaves isOwned = 1 on many titles that are only available
+          through Game Pass (e.g. Starfield, Sea of Thieves). Those are still
+          listed in SubscriptionReleases, which maps each subscription to its
+          releases, so we exclude anything present there as well.
+
+        A title is dropped if either signal says subscription. Titles that left
+        Game Pass entirely are removed from SubscriptionReleases yet keep
+        isOwned = 1, so they remain indistinguishable from genuine purchases and
+        cannot be filtered here.
         """
         try:
             self.cursor.execute("""SELECT lr.releaseKey
                    FROM LibraryReleases lr
-                   JOIN LicensedReleases lic ON lr.id = lic.libraryId
-                   WHERE lic.isOwned = 0""")
+                   LEFT JOIN LicensedReleases lic ON lr.id = lic.libraryId
+                   LEFT JOIN SubscriptionReleases sr ON lr.id = sr.licenseId
+                   WHERE lic.isOwned = 0 OR sr.licenseId IS NOT NULL""")
         except sqlite3.OperationalError:
             # Older GOG Galaxy schemas may lack these tables; degrade gracefully.
-            log.warning("LicensedReleases/LibraryReleases not found; skipping #120 fix")
+            log.warning(
+                "LicensedReleases/SubscriptionReleases not found; skipping #120 fix"
+            )
             return set()
         return {row[0] for row in self.cursor.fetchall()}
 

--- a/tests/test_gogdb.py
+++ b/tests/test_gogdb.py
@@ -42,6 +42,9 @@ def _build_gog_db(path: str) -> None:
         ("xboxone_100", "GamePassGone", 0, False, ["xboxone_100"]),
         # Genuinely purchased Xbox title: isOwned = 1, must be kept.
         ("xboxone_200", "RealXbox", 1, False, ["xboxone_200"]),
+        # Current Game Pass title GOG wrongly flags isOwned = 1, but it is still
+        # listed in SubscriptionReleases, so the #120 fix must drop it too.
+        ("xboxone_300", "GamePassOwnedFlag", 1, False, ["xboxone_300"]),
     ]
 
     for rk, title, _owned, _installed, releases in games:
@@ -64,9 +67,22 @@ def _build_gog_db(path: str) -> None:
         "(id INTEGER PRIMARY KEY, userId INTEGER, releaseKey TEXT)"
     )
     c.execute("CREATE TABLE LicensedReleases (libraryId INTEGER, isOwned BOOLEAN)")
+    library_ids = {}
     for i, (rk, _t, owned, _inst, _r) in enumerate(games, start=1):
+        library_ids[rk] = i
         c.execute("INSERT INTO LibraryReleases VALUES (?, ?, ?)", (i, 12345, rk))
         c.execute("INSERT INTO LicensedReleases VALUES (?, ?)", (i, 1 if owned else 0))
+
+    # SubscriptionReleases lists titles available through a subscription, keyed
+    # by libraryId. xboxone_300 sits here despite isOwned = 1 (see #120 fix).
+    c.execute(
+        "CREATE TABLE SubscriptionReleases "
+        "(id INTEGER PRIMARY KEY, subscriptionId INTEGER, licenseId INTEGER)"
+    )
+    c.execute(
+        "INSERT INTO SubscriptionReleases (subscriptionId, licenseId) VALUES (?, ?)",
+        (1, library_ids["xboxone_300"]),
+    )
 
     # Installed-games query plumbing: steam_1 is installed.
     c.execute("CREATE TABLE Platforms (id INTEGER, name TEXT)")
@@ -103,8 +119,10 @@ def test_parse_excludes_expired_game_pass(gog_db):
 
     assert parsed.user_id == "12345"
     keys = {e["release_key"] for e in parsed.entries}
-    # Expired Game Pass title dropped; purchased Xbox title kept.
+    # Game Pass titles dropped (isOwned = 0 and the isOwned = 1 / in-subscription
+    # case); purchased Xbox title kept.
     assert "xboxone_100" not in keys
+    assert "xboxone_300" not in keys
     assert "xboxone_200" in keys
     assert {"steam_1", "gog_2", "xboxone_200"} == keys
 
@@ -115,7 +133,7 @@ def test_subscription_release_keys(gog_db):
         excluded = parser.get_subscription_release_keys()
     finally:
         parser.close()
-    assert excluded == {"xboxone_100"}
+    assert excluded == {"xboxone_100", "xboxone_300"}
 
 
 def test_installed_and_igdb_key(gog_db):


### PR DESCRIPTION
## Problem

This filters out more Xbox titles that are no longer owned; the full fix needs to happen in the GOG integration.

The v2 #120 fix (`get_subscription_release_keys`) excludes Xbox titles only when `LicensedReleases.isOwned = 0`. But on my current DB, **42 Xbox titles survive that filter while only 1 is genuinely owned**.

The cause: `isOwned` is unreliable. All 42 survivors have `isOwned = 1`, including obvious Game Pass titles — Starfield, Sea of Thieves, Hades, Persona 5 Royal, Gears of War 4, etc. GOG never flips the flag when those leave the library/subscription.

## Fix

GOG also tracks subscription membership in `SubscriptionReleases` (each Game Pass tier → `LicensedReleases.libraryId`). 21 of the 42 survivors are listed there despite `isOwned = 1`. This change excludes a release if **either** signal says subscription:

```sql
WHERE lic.isOwned = 0 OR sr.licenseId IS NOT NULL
```

On my DB this drops the false-positive Xbox count from **42 → 21**.

## Known limitation

The remaining 21 are titles that left Game Pass *entirely* (Hades, Persona 5 Royal, The Outer Worlds, Dead Cells, …). GOG removes them from `SubscriptionReleases` but keeps `isOwned = 1` and their `ProductPurchaseDates` rows, leaving them byte-for-byte indistinguishable from genuine purchases — no DB field separates them from the one truly-owned title. Filtering those would require a manual per-user exclude list (not in this PR).

## Testing

- Added a test case: an Xbox title with `isOwned = 1` that is present in `SubscriptionReleases` is now excluded.
- `83 passed` locally; verified against a real post-subscription DB (772 excluded, 21 kept).

🤖 Generated with [Claude Code](https://claude.com/claude-code)