### PR TITLE
Count unique games in the header, not table rows

### DIFF
--- a/src/gamatrix/games/service.py
+++ b/src/gamatrix/games/service.py
@@ -89,7 +89,11 @@ def compare(repo: Repository, opts: CompareOptions) -> CompareResult:
         reverse=opts.direction == "desc",
     )
 
-    total = len(games)
+    # Count unique games, not rows: the grid view can list the same title on
+    # more than one row when platform copies have different owners, but those
+    # are still one game. Rows are already grouped by slug, so distinct slugs
+    # is the unique-game count.
+    total = len({g["slug"] for g in games})
     if opts.randomize and games:
         games = [random.choice(games)]
 

--- a/tests/test_games.py
+++ b/tests/test_games.py
@@ -132,3 +132,39 @@ def test_merge_cross_platform_duplicates(repo):
     result = compare(repo, CompareOptions(selected_user_ids=["1"]))
     assert len(result.games) == 1
     assert sorted(result.games[0]["platforms"]) == ["gog", "steam"]
+
+
+def test_count_is_unique_games_not_rows(repo):
+    """The header count is unique games, not table rows.
+
+    In the grid view the same title can occupy two rows when platform copies
+    have different owners (so they don't merge); that's still one game.
+    """
+    repo.put_user({"email": "a@x.com", "username": "A", "user_id": "1"})
+    repo.put_user({"email": "b@x.com", "username": "B", "user_id": "2"})
+    for rk, platform in [("steam_40", "steam"), ("gog_41", "gog")]:
+        repo.put_game(
+            {
+                "release_key": rk,
+                "title": "Split Game",
+                "slug": "splitgame",
+                "igdb_key": rk,
+                "platform": platform,
+                "multiplayer": True,
+                "max_players": 4,
+                "rating": 0,
+                "game_modes": [],
+                "enrichment_status": "done",
+            }
+        )
+    # User 1 owns it on Steam, user 2 on GOG: different owner sets keep the two
+    # rows separate rather than merging into one.
+    repo.replace_user_library(
+        "1", [{"release_key": "steam_40", "platform": "steam", "installed": False}]
+    )
+    repo.replace_user_library(
+        "2", [{"release_key": "gog_41", "platform": "gog", "installed": False}]
+    )
+    result = compare(repo, CompareOptions(selected_user_ids=["1", "2"], all_games=True))
+    assert len(result.games) == 2  # two rows
+    assert result.total == 1  # but one unique game


### PR DESCRIPTION
## Problem

The results header showed the number of table **rows**, not the number of unique games. In the grid view the same title can occupy more than one row when platform copies have different owners — those rows don't merge (the merge key is `(slug, owners)`), so a single game was counted twice.

## Fix

Compute the header total from **distinct slugs** among the displayed games instead of `len(games)`. Rows are already grouped by slug, so distinct slugs is the unique-game count.

```python
total = len({g["slug"] for g in games})
```

This flows through `build_caption()` into the `<caption>` header (both normal and grid views) and the "Random game selected from N" text. Row rendering is unchanged — two rows still display when ownership differs; only the count reflects unique games.

## Testing

- Added `test_count_is_unique_games_not_rows`: one title owned by different users on different platforms produces 2 rows but `result.total == 1`.
- Full suite: 104 passed; black / flake8 / mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)