### PR TITLE
Show DB upload time in the viewer's local time zone

### DIFF
--- a/src/gamatrix/templates/games.html.jinja
+++ b/src/gamatrix/templates/games.html.jinja
@@ -27,7 +27,10 @@
     <fieldset class="filter-group">
         <legend>Users</legend>
         {% for uid, u in users.items() %}
-        <label title="DB updated: {{ u.get('db_updated_at', 'never') }}">
+        {# Server stores db_updated_at as UTC; the title here is a no-JS
+           fallback that the script below rewrites in the viewer's local time. #}
+        <label class="db-updated" data-db-updated="{{ u.get('db_updated_at', '') }}"
+               title="DB updated: {{ u.get('db_updated_at', 'never') }}">
             <input type="checkbox" name="user" value="{{ uid }}"
                    {% if uid in opts.selected_user_ids %}checked{% endif %}>
             {% set pu = pic_url(u) %}
@@ -95,4 +98,19 @@
 <div id="games-container">
     {% include "games_table.html.jinja" %}
 </div>
+
+<script>
+// DB upload times are stored as UTC. Rewrite each user's hover tooltip in the
+// viewer's local time zone; toLocaleString() picks up the browser's locale and
+// zone automatically. The filter form renders once, so a single pass is enough.
+(function () {
+    for (const el of document.querySelectorAll('.db-updated[data-db-updated]')) {
+        const iso = el.dataset.dbUpdated;
+        if (!iso) { continue; }
+        const when = new Date(iso);
+        if (isNaN(when)) { continue; }
+        el.title = 'DB updated: ' + when.toLocaleString();
+    }
+}());
+</script>
 {% endblock %}


### PR DESCRIPTION
## What

Hovering over a user in the filter list shows their DB upload time. It was rendered as the raw stored UTC ISO string (e.g. `DB updated: 2026-06-11T14:32:00+00:00`). This converts it to the viewer's local time zone, e.g. `6/11/2026, 7:32:00 AM`.

## How

The server can't know the viewer's time zone, but the browser can, so the conversion happens client-side:

- `db_updated_at` (an unambiguous UTC instant) is rendered into a `data-db-updated` attribute on the user `<label>`.
- A small inline script rewrites each tooltip with `new Date(iso).toLocaleString()`, which automatically uses the browser's locale and time zone — no TZ plumbing or stored preference needed.

The original server-rendered `title` stays in place as a no-JS fallback. The filter form renders only once (HTMX swaps only `#games-container`), so a single pass on page load covers every label.

## Testing

- `uv run pytest tests/test_gogdb.py tests/test_games.py` — passes (15).
- Jinja template parse-checked.

No backend or data changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)