### PR TITLE
Fix bug requesting users password from plain-text dialog in passkey revocation flow

### DIFF
--- a/src/gamatrix/auth/routes.py
+++ b/src/gamatrix/auth/routes.py
@@ -92,6 +92,22 @@ def _passkey_credentials(user: dict, repo: Repository) -> list[dict]:
     return repo.list_passkeys(user_handle) if user_handle else []
 
 
+def _owned_passkey(credential_id: str, user: dict, repo: Repository) -> dict:
+    user_handle = user.get("webauthn_user_id")
+    if not user_handle:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="No passkeys are registered for this account.",
+        )
+    passkey = repo.get_passkey(credential_id)
+    if not passkey or passkey.get("user_handle") != user_handle:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Passkey not found for this account.",
+        )
+    return passkey
+
+
 @router.get("/passkeys", response_class=HTMLResponse)
 def passkey_management(
     request: Request,
@@ -115,6 +131,61 @@ def list_passkeys(
         request,
         "passkeys_list.html.jinja",
         {"passkeys": _passkey_credentials(user, repo)},
+    )
+
+
+@router.get("/passkeys/manage/list", response_class=HTMLResponse)
+def manage_passkeys_list(
+    request: Request,
+    user: dict = Depends(current_user_api),
+    repo: Repository = Depends(get_repo),
+):
+    return templates.TemplateResponse(
+        request,
+        "passkeys_manage_list.html.jinja",
+        {"passkeys": _passkey_credentials(user, repo)},
+    )
+
+
+@router.get("/passkeys/{credential_id}/delete", response_class=HTMLResponse)
+def confirm_delete_passkey(
+    credential_id: str,
+    request: Request,
+    user: dict = Depends(current_user_api),
+    repo: Repository = Depends(get_repo),
+):
+    return templates.TemplateResponse(
+        request,
+        "passkey_delete_form.html.jinja",
+        {"passkey": _owned_passkey(credential_id, user, repo), "error": None},
+    )
+
+
+@router.post("/passkeys/{credential_id}/delete", response_class=HTMLResponse)
+def delete_passkey_inline(
+    credential_id: str,
+    request: Request,
+    password: str = Form(...),
+    user: dict = Depends(current_user_api),
+    repo: Repository = Depends(get_repo),
+):
+    passkey = _owned_passkey(credential_id, user, repo)
+    if not service.authenticate(repo, user["email"], password):
+        return templates.TemplateResponse(
+            request,
+            "passkey_delete_form.html.jinja",
+            {"passkey": passkey, "error": "Wrong password."},
+        )
+    if not repo.delete_passkey(credential_id, user["webauthn_user_id"]):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Passkey not found for this account.",
+        )
+    return templates.TemplateResponse(
+        request,
+        "passkeys_manage_list.html.jinja",
+        {"passkeys": _passkey_credentials(user, repo)},
+        headers={"HX-Retarget": "#passkey-list", "HX-Reswap": "outerHTML"},
     )
 
 

--- a/src/gamatrix/static/passkeys.js
+++ b/src/gamatrix/static/passkeys.js
@@ -133,22 +133,6 @@
         showError(error);
       }
     });
-    document.querySelectorAll(".delete-passkey").forEach((button) => {
-      button.addEventListener("click", async () => {
-        const password = window.prompt("Confirm your current password to delete this passkey:");
-        if (!password) return;
-        try {
-          await json(`/auth/passkeys/${encodeURIComponent(button.dataset.credentialId)}`, {
-            method: "DELETE",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ password: password }),
-          });
-          window.location.reload();
-        } catch (error) {
-          showError(error);
-        }
-      });
-    });
   }
 
   window.gamatrixPasskeys = { enableLogin, enableManagement };

--- a/src/gamatrix/static/style.css
+++ b/src/gamatrix/static/style.css
@@ -140,6 +140,10 @@ table.results td.unowned { background-color: var(--unowned); }
   display: flex; gap: 1rem; align-items: center; margin: 0.75rem 0;
 }
 .passkey-list li .muted, .token-list li .muted { flex: 1; }
+.passkey-delete-confirm { align-items: flex-start !important; flex-direction: column; }
+.passkey-delete-confirm form { display: flex; flex-wrap: wrap; gap: 0.5rem; align-items: center; width: 100%; }
+.passkey-delete-confirm label { display: flex; gap: 0.5rem; align-items: center; }
+.passkey-delete-confirm input[type=password] { padding: 6px; border-radius: 4px; border: 1px solid #888; }
 .token-box {
   white-space: pre-wrap;
   word-break: break-all;

--- a/src/gamatrix/templates/passkey_delete_form.html.jinja
+++ b/src/gamatrix/templates/passkey_delete_form.html.jinja
@@ -1,0 +1,16 @@
+<li class="passkey-delete-confirm">
+    <strong>Delete {{ passkey.friendly_name }}?</strong>
+    <form hx-post="/auth/passkeys/{{ passkey.credential_id }}/delete"
+          hx-target="closest li" hx-swap="outerHTML">
+        <label>
+            Current password
+            <input type="password" name="password" required
+                   autocomplete="current-password" autofocus>
+        </label>
+        <button type="submit">Confirm delete</button>
+        <button type="button" class="secondary"
+                hx-get="/auth/passkeys/manage/list"
+                hx-target="#passkey-list" hx-swap="outerHTML">Cancel</button>
+        {% if error %}<span class="error">{{ error }}</span>{% endif %}
+    </form>
+</li>

--- a/src/gamatrix/templates/passkeys.html.jinja
+++ b/src/gamatrix/templates/passkeys.html.jinja
@@ -26,24 +26,7 @@
 
 <div class="card wide">
     <h3>Registered passkeys</h3>
-    {% if passkeys %}
-    <ul class="passkey-list">
-        {% for passkey in passkeys %}
-        <li>
-            <strong>{{ passkey.friendly_name }}</strong>
-            <span class="muted">
-                {% if passkey.backup_eligible %}sync-capable{% else %}device-bound{% endif %}
-                {% if passkey.backed_up %}, backed up{% endif %}
-                {% if passkey.created_at %} - added {{ passkey.created_at[:10] }}{% endif %}
-            </span>
-            <button type="button" class="secondary delete-passkey"
-                    data-credential-id="{{ passkey.credential_id }}">Delete</button>
-        </li>
-        {% endfor %}
-    </ul>
-    {% else %}
-    <p class="muted">No passkeys registered.</p>
-    {% endif %}
+    {% include "passkeys_manage_list.html.jinja" %}
 </div>
 <script src="/static/passkeys.js"></script>
 <script>window.gamatrixPasskeys.enableManagement();</script>

--- a/src/gamatrix/templates/passkeys_manage_list.html.jinja
+++ b/src/gamatrix/templates/passkeys_manage_list.html.jinja
@@ -1,0 +1,21 @@
+<div id="passkey-list">
+    {% if passkeys %}
+    <ul class="passkey-list">
+        {% for passkey in passkeys %}
+        <li>
+            <strong>{{ passkey.friendly_name }}</strong>
+            <span class="muted">
+                {% if passkey.backup_eligible %}sync-capable{% else %}device-bound{% endif %}
+                {% if passkey.backed_up %}, backed up{% endif %}
+                {% if passkey.created_at %} - added {{ passkey.created_at[:10] }}{% endif %}
+            </span>
+            <button type="button" class="secondary"
+                    hx-get="/auth/passkeys/{{ passkey.credential_id }}/delete"
+                    hx-target="closest li" hx-swap="outerHTML">Delete</button>
+        </li>
+        {% endfor %}
+    </ul>
+    {% else %}
+    <p class="muted">No passkeys registered.</p>
+    {% endif %}
+</div>

--- a/tests/test_passkeys.py
+++ b/tests/test_passkeys.py
@@ -54,7 +54,17 @@ def test_login_page_offers_explicit_and_conditional_passkeys(repo):
 
 
 def test_passkey_management_page_prefills_name_and_explains_password(repo):
-    _user(repo)
+    user = _user(repo)
+    handle = repo.ensure_webauthn_user_id(user["email"], "opaque-handle")
+    repo.put_passkey(
+        {
+            "credential_id": "credential",
+            "user_handle": handle,
+            "email": user["email"],
+            "sign_count": 0,
+            "friendly_name": "Laptop",
+        }
+    )
     for client in _client(repo):
         _login(client)
         response = client.get("/auth/passkeys")
@@ -64,6 +74,8 @@ def test_passkey_management_page_prefills_name_and_explains_password(repo):
             "Required to verify your identity before adding a passkey" in response.text
         )
         assert "Waiting for passkey creation to complete..." in response.text
+        assert 'hx-get="/auth/passkeys/credential/delete"' in response.text
+        assert "window.prompt" not in client.get("/static/passkeys.js").text
 
 
 def test_preferences_page_moves_manage_passkeys_into_page_body(repo):
@@ -247,6 +259,66 @@ def test_listing_hides_key_material_and_deletion_requires_password(repo):
             == 200
         )
         assert repo.get_passkey("credential") is None
+
+
+def test_inline_passkey_deletion_uses_password_field_and_refreshes_list(repo):
+    user = _user(repo)
+    handle = repo.ensure_webauthn_user_id(user["email"], "opaque-handle")
+    repo.put_passkey(
+        {
+            "credential_id": "credential",
+            "public_key": "secret-public-key",
+            "user_handle": handle,
+            "email": user["email"],
+            "sign_count": 0,
+            "friendly_name": "Laptop",
+        }
+    )
+    for client in _client(repo):
+        _login(client)
+
+        confirmation = client.get("/auth/passkeys/credential/delete")
+        assert confirmation.status_code == 200
+        assert "Delete Laptop?" in confirmation.text
+        assert 'type="password"' in confirmation.text
+        assert 'autocomplete="current-password"' in confirmation.text
+        assert "secret-public-key" not in confirmation.text
+
+        denied = client.post(
+            "/auth/passkeys/credential/delete", data={"password": "wrong"}
+        )
+        assert denied.status_code == 200
+        assert "Wrong password." in denied.text
+        assert 'value="wrong"' not in denied.text
+        assert repo.get_passkey("credential") is not None
+
+        deleted = client.post(
+            "/auth/passkeys/credential/delete", data={"password": "password"}
+        )
+        assert deleted.status_code == 200
+        assert deleted.headers["hx-retarget"] == "#passkey-list"
+        assert "Laptop" not in deleted.text
+        assert "No passkeys registered." in deleted.text
+        assert repo.get_passkey("credential") is None
+
+
+def test_inline_passkey_deletion_does_not_expose_another_accounts_passkey(repo):
+    user = _user(repo)
+    repo.ensure_webauthn_user_id(user["email"], "own-handle")
+    repo.put_passkey(
+        {
+            "credential_id": "other-credential",
+            "user_handle": "other-handle",
+            "email": "other@example.com",
+            "sign_count": 0,
+            "friendly_name": "Other laptop",
+        }
+    )
+    for client in _client(repo):
+        _login(client)
+        confirmation = client.get("/auth/passkeys/other-credential/delete")
+        assert confirmation.status_code == 404
+        assert "Other laptop" not in confirmation.text
 
 
 def test_delete_passkey_returns_explicit_404_without_registered_handle(repo):


### PR DESCRIPTION
Fix for #163 

Improvements to inline passkey revocation.

  - Replaced window.prompt with an inline HTMX confirmation form using a masked password field.
  - Added cancel, inline wrong-password feedback, and list refresh after deletion.
  - Enforced passkey ownership before exposing confirmation details.
  - Preserved the existing JSON delete endpoint.

## Checklist

- [ ] PR checks pass
- [ ] Tests added/updated for the change
- [ ] Version label applied if this is more than a patch (see below)

NOTE: I have *not* tested this locally yet! (Waiting for #165 to land)...