### PR TITLE
Show API token last-used time in the viewer's local time zone

### DIFF
--- a/src/gamatrix/templates/tokens.html.jinja
+++ b/src/gamatrix/templates/tokens.html.jinja
@@ -68,6 +68,23 @@
         htmx.ajax("GET", "/auth/tokens/list", { target: "#token-list" });
     }
 
+    // Last-used times are stored as UTC. Rewrite each one in the viewer's local
+    // time zone; toLocaleString() picks up the browser's locale and zone
+    // automatically. The list is fetched and re-fetched via HTMX, so run this
+    // after every swap into #token-list.
+    function localizeLastUsed() {
+        for (const el of document.querySelectorAll(".token-last-used[data-last-used]")) {
+            const iso = el.dataset.lastUsed;
+            if (!iso) { continue; }
+            const when = new Date(iso);
+            if (isNaN(when)) { continue; }
+            el.textContent = when.toLocaleString();
+        }
+    }
+    document.body.addEventListener("htmx:afterSwap", (event) => {
+        if (event.target.id === "token-list") { localizeLastUsed(); }
+    });
+
     async function copy(text, button) {
         try {
             await navigator.clipboard.writeText(text);

--- a/src/gamatrix/templates/tokens_list.html.jinja
+++ b/src/gamatrix/templates/tokens_list.html.jinja
@@ -5,7 +5,11 @@
         <strong>{{ t.name }}</strong>
         <span class="muted">
             {% if t.created_at %}added {{ t.created_at[:10] }}{% endif %}
-            {% if t.last_used_at %}· last used {{ t.last_used_at[:10] }}{% else %}· never used{% endif %}
+            {# Server stores last_used_at as UTC; the text here is a no-JS
+               fallback that the script in tokens.html.jinja rewrites in the
+               viewer's local time. #}
+            {% if t.last_used_at %}· last used <span class="token-last-used"
+                  data-last-used="{{ t.last_used_at }}">{{ t.last_used_at[:10] }}</span>{% else %}· never used{% endif %}
         </span>
         <button type="button" class="secondary delete-token"
                 data-token-id="{{ t.token_id }}">Revoke</button>

--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -113,6 +113,21 @@ def test_create_token_returns_secret_and_setup_snippet(repo):
         assert "laptop" in listing.text
 
 
+def test_token_list_exposes_last_used_for_client_localization(repo):
+    # The server can't know the viewer's time zone, so it renders the raw UTC
+    # timestamp into a data attribute the browser localizes (mirrors the DB
+    # upload time). A used token carries that attribute; an unused one doesn't.
+    _seed_user(repo)
+    token = tokens.create_api_token(repo, "user@example.com", "laptop")
+    for client in _client(repo):
+        _login(client)
+        assert "data-last-used" not in client.get("/auth/tokens/list").text
+        tokens.resolve_token(repo, token)
+        stored = repo.list_api_tokens("user@example.com")[0]["last_used_at"]
+        listing = client.get("/auth/tokens/list").text
+        assert f'data-last-used="{stored}"' in listing
+
+
 def test_revoke_token_removes_it(repo):
     _seed_user(repo)
     token = tokens.create_api_token(repo, "user@example.com", "laptop")


### PR DESCRIPTION
## What

The API tokens management page rendered each token's `last_used_at` as the raw stored **UTC** date. This localizes it to the viewer's browser time zone, mirroring how the DB upload time was handled in #161.

## How

- `tokens_list.html.jinja`: render the UTC instant into a `data-last-used` attribute on a `.token-last-used` span, keeping the server-rendered date as a no-JS fallback.
- `tokens.html.jinja`: rewrite each span with `toLocaleString()`, which picks up the browser's locale and zone automatically. The list is fetched and re-fetched via HTMX (on load, and after create/revoke), so the rewrite runs on every `htmx:afterSwap` into `#token-list`.

`last_used_at` is stored via `now_iso()` as a UTC ISO string with a `+00:00` offset, so `new Date(iso)` parses it unambiguously — same as `db_updated_at`.

## Test

Added `test_token_list_exposes_last_used_for_client_localization`, asserting the rendered list carries the raw UTC timestamp in `data-last-used` once a token has been used (and not before). `just lint` and `pytest tests/test_tokens.py` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)