### PR TITLE
Personalize uploader scripts and rename the scheduled task

### DIFF
--- a/src/gamatrix/auth/routes.py
+++ b/src/gamatrix/auth/routes.py
@@ -2,8 +2,15 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 from fastapi import APIRouter, Depends, Form, HTTPException, Request, status
-from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
+from fastapi.responses import (
+    HTMLResponse,
+    JSONResponse,
+    PlainTextResponse,
+    RedirectResponse,
+)
 from pydantic import BaseModel
 
 from gamatrix.auth import passkeys, service, tokens
@@ -218,16 +225,40 @@ def _token_setup_snippet(token: str) -> str:
         "$acl.SetAccessRule($rule)\n"
         "Set-Acl -Path $tokenPath -AclObject $acl\n\n"
         "# 2) Download the uploader script.\n"
-        f'Invoke-WebRequest "{base_url}/static/upload-gamatrix.ps1" '
+        f'Invoke-WebRequest "{base_url}/auth/upload-gamatrix.ps1" '
         '-OutFile "$dir\\upload-gamatrix.ps1"\n\n'
         "# 3) Schedule a daily upload at 5am (adjust the time as you like).\n"
         "$action = New-ScheduledTaskAction -Execute powershell.exe -Argument "
         f'"-ExecutionPolicy Bypass -File `"$dir\\upload-gamatrix.ps1`" '
         f'-BaseUrl {base_url}"\n'
         "$trigger = New-ScheduledTaskTrigger -Daily -At 5am\n"
-        "Register-ScheduledTask -TaskName 'Gamatrix DB upload' -Action $action "
-        "-Trigger $trigger\n"
+        # A v2-specific task name so it doesn't collide with a leftover v1 task.
+        "Register-ScheduledTask -TaskName 'gamatrix v2 DB upload' "
+        "-Action $action -Trigger $trigger\n"
     )
+
+
+# The uploader scripts ship with a generic placeholder host; we swap it for this
+# deployment's real base URL when serving so the copy a user downloads points at
+# the right site out of the box (rather than the example in the source).
+_STATIC_DIR = Path(__file__).resolve().parent.parent / "static"
+_PLACEHOLDER_BASE_URL = "https://gamatrix.example.com"
+
+
+def _personalized_uploader(filename: str) -> str:
+    base_url = get_settings().app_base_url.rstrip("/")
+    text = (_STATIC_DIR / filename).read_text(encoding="utf-8")
+    return text.replace(_PLACEHOLDER_BASE_URL, base_url)
+
+
+@router.get("/upload-gamatrix.ps1", response_class=PlainTextResponse)
+def uploader_script_ps1() -> str:
+    return _personalized_uploader("upload-gamatrix.ps1")
+
+
+@router.get("/upload-gamatrix.sh", response_class=PlainTextResponse)
+def uploader_script_sh() -> str:
+    return _personalized_uploader("upload-gamatrix.sh")
 
 
 @router.get("/tokens", response_class=HTMLResponse)

--- a/src/gamatrix/templates/tokens.html.jinja
+++ b/src/gamatrix/templates/tokens.html.jinja
@@ -42,7 +42,7 @@
     <pre id="token-snippet" class="token-box"></pre>
     <button type="button" id="copy-snippet">Copy setup script</button>
     <p class="muted">On macOS or Linux, download
-    <a href="{{ base_url }}/static/upload-gamatrix.sh">upload-gamatrix.sh</a>,
+    <a href="{{ base_url }}/auth/upload-gamatrix.sh">upload-gamatrix.sh</a>,
     save the token to a file only you can read
     (<code>chmod 600 ~/.gamatrix-token</code>), and run the script from cron.
     It needs <code>curl</code> and <code>python3</code> on the

--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -107,10 +107,26 @@ def test_create_token_returns_secret_and_setup_snippet(repo):
         assert body["token"] in body["snippet"]
         assert "/upload/presign" not in body["snippet"]  # the script handles that
         assert "Set-Acl" in body["snippet"]
-        assert "upload-gamatrix.ps1" in body["snippet"]
+        assert "/auth/upload-gamatrix.ps1" in body["snippet"]
+        # A v2-specific task name, so it can't collide with a leftover v1 task.
+        assert "gamatrix v2 DB upload" in body["snippet"]
         # The new token shows up on the management page.
         listing = client.get("/auth/tokens/list")
         assert "laptop" in listing.text
+
+
+def test_uploader_scripts_point_at_the_configured_site(repo):
+    # The scripts ship with a placeholder host; serving them swaps in this
+    # deployment's real base URL so the download works without hand-editing.
+    from gamatrix.config import get_settings
+
+    base_url = get_settings().app_base_url.rstrip("/")
+    for client in _client(repo):
+        for name in ("upload-gamatrix.ps1", "upload-gamatrix.sh"):
+            resp = client.get(f"/auth/{name}")
+            assert resp.status_code == 200
+            assert "gamatrix.example.com" not in resp.text
+            assert base_url in resp.text
 
 
 def test_revoke_token_removes_it(repo):


### PR DESCRIPTION
Two fixes to the unattended-upload setup handed out on the **API tokens** page.

## 1. Scripts pointed at a placeholder host

The downloadable uploader scripts (`upload-gamatrix.ps1` / `.sh`) shipped a generic `https://gamatrix.example.com` default, so anyone who ran one without overriding the base URL hit the wrong site.

The server already knows the deployment's real site (`app_base_url`), so the scripts are now served through `GET /auth/upload-gamatrix.ps1` and `GET /auth/upload-gamatrix.sh`, which read the script and substitute the placeholder for the configured base URL. The PowerShell setup snippet and the macOS/Linux download link reference those routes, so the copy a user gets points at the right host out of the box — no hand-editing.

(The routes are public, matching how the PowerShell `Invoke-WebRequest` fetches the script with no cookie.)

## 2. Scheduled-task name collided with v1

The setup snippet registered the Windows task as `'Gamatrix DB upload'` — the same name v1 used, which conflicts if a v1 task is still defined. Renamed to `'gamatrix v2 DB upload'`.

## Test

- Added `test_uploader_scripts_point_at_the_configured_site`: both served scripts return 200, contain the configured base URL, and no longer contain `gamatrix.example.com`.
- Extended the snippet test to assert the `/auth/upload-gamatrix.ps1` download URL and the `gamatrix v2 DB upload` task name.
- `just lint`, `just typecheck`, and `pytest tests/test_tokens.py` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)