### PR TITLE
[1/3] Separate data and UX layers to make UX updates more independant

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,7 +104,7 @@ Shared infrastructure concerns are centralized:
 
 - Route handlers should depend on the storage/auth abstractions instead of constructing clients inline. Use `Repository` via `get_repo()` / `get_repository()`, and reuse `get_s3()` / `get_queue()` for AWS-facing operations.
 - Persisted game data is keyed by `release_key`, but the compare view deliberately merges duplicate titles by `(slug, owners)` so the same game across platforms collapses into one row only when the owner set is identical.
-- Saved user preferences live on the user record in DynamoDB. Always merge stored preferences with `DEFAULT_PREFERENCES`, and keep the request overlay behavior consistent with `_parse_options()` in `games/routes.py` and `merge_preferences()` in [`games/preferences.py`](/src/gamatrix/games/preferences.py).
+- Saved user preferences live on the user record in DynamoDB. Always merge stored preferences with `DEFAULT_PREFERENCES`, and keep the request overlay behavior consistent with `parse_options()` in `games/web.py` and `merge_preferences()` in [`games/preferences.py`](/src/gamatrix/games/preferences.py).
 - Page routes and HTMX/API routes use different auth dependencies on purpose: `current_user()` redirects unauthenticated browsers to login, while `current_user_api()` returns `401` for fragment/API calls.
 - Local development does not mirror AWS exactly. `/upload/complete` ingests inline only when `LOCAL_DEV=true`, and the local worker polls the jobs table because there is no local SQS event source.
 - The repository layer normalizes DynamoDB types and identifiers for the rest of the app: emails are lowercased on write, `user_id` values are treated as strings, and floats are converted to `Decimal` before writes.

--- a/src/gamatrix/games/api.py
+++ b/src/gamatrix/games/api.py
@@ -1,0 +1,29 @@
+"""JSON serialization for the comparison application contract."""
+
+from __future__ import annotations
+
+from gamatrix.games.service import ComparisonDataset, ComparisonQuery
+
+
+def serialize_comparison(
+    query: ComparisonQuery,
+    dataset: ComparisonDataset,
+) -> dict:
+    """Serialize a comparison query and dataset for headless consumers."""
+    return {
+        "query": {
+            "selected_user_ids": list(query.selected_user_ids),
+            "include_single_player": query.include_single_player,
+            "installed_only": query.installed_only,
+            "exclude_platforms": list(query.exclude_platforms),
+            "exclusive": query.exclusive,
+            "scope": query.scope,
+            "sort": {
+                "field": query.sort.field,
+                "direction": query.sort.direction,
+            },
+        },
+        "total": dataset.total,
+        "excluded_user_ids": list(dataset.excluded_user_ids),
+        "games": [item.to_dict() for item in dataset.items],
+    }

--- a/src/gamatrix/games/routes.py
+++ b/src/gamatrix/games/routes.py
@@ -3,8 +3,7 @@
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends, Request
-from fastapi.responses import HTMLResponse
-from fastapi.responses import JSONResponse
+from fastapi.responses import HTMLResponse, JSONResponse
 
 from gamatrix.auth.dependencies import (
     current_user,
@@ -29,15 +28,6 @@ from gamatrix.templating import templates
 router = APIRouter(tags=["games"])
 
 
-def _parse_options(
-    request: Request,
-    user: dict,
-    repo: Repository | None = None,
-) -> WebCompareOptions:
-    """Build web options from saved preferences overlaid with query params."""
-    return web.parse_options(request, user, repo or get_repo())
-
-
 def _maybe_enrich(repo: Repository, opts: WebCompareOptions) -> str | None:
     """Find stale/pending games among the selected libraries and enqueue a job.
 
@@ -55,7 +45,7 @@ def games_page(
     user: dict = Depends(current_user),
     repo: Repository = Depends(get_repo),
 ):
-    opts = _parse_options(request, user, repo)
+    opts = web.parse_options(request, user, repo)
     job_id = _maybe_enrich(repo, opts)
     users = {str(u["user_id"]): u for u in repo.scan_users() if u.get("user_id")}
     result = service.compare(repo, opts.to_query())
@@ -84,7 +74,7 @@ def games_table(
     repo: Repository = Depends(get_repo),
 ):
     users = {str(u["user_id"]): u for u in repo.scan_users() if u.get("user_id")}
-    opts = _parse_options(request, user, repo)
+    opts = web.parse_options(request, user, repo)
     result = service.compare(repo, opts.to_query())
     caption = web.build_caption(users, opts, result)
     return templates.TemplateResponse(
@@ -107,7 +97,7 @@ def games_api(
     repo: Repository = Depends(get_repo),
 ):
     """Return the comparison dataset as JSON for headless consumers."""
-    opts = _parse_options(request, user, repo)
+    opts = web.parse_options(request, user, repo)
     query = opts.to_query()
     result = service.compare(repo, query)
     return JSONResponse(api.serialize_comparison(query, result))

--- a/src/gamatrix/games/routes.py
+++ b/src/gamatrix/games/routes.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from fastapi import APIRouter, Depends, Request
 from fastapi.responses import HTMLResponse
+from fastapi.responses import JSONResponse
 
 from gamatrix.auth.dependencies import (
     current_user,
@@ -11,108 +12,41 @@ from gamatrix.auth.dependencies import (
     get_repo,
     require_admin,
 )
-from gamatrix.config import get_settings
 from gamatrix.constants import (
     ENRICHMENT_NOT_FOUND,
     ENRICHMENT_PENDING,
     JOB_COMPLETED,
     JOB_FAILED,
 )
-from gamatrix.games import service
+from gamatrix.games import api, service, web
 from gamatrix.games.preferences import merge_preferences
-from gamatrix.games.service import CompareOptions
-from gamatrix.helpers import parse_iso
+from gamatrix.games.web import WebCompareOptions
 from gamatrix.jobs import create_enrichment_job, is_job_stale
 from gamatrix.storage.dynamo import Repository
 from gamatrix.storage.queue import get_queue
 from gamatrix.templating import templates
-from datetime import datetime, timedelta, timezone
 
 router = APIRouter(tags=["games"])
 
 
-def _parse_options(request: Request, user: dict) -> CompareOptions:
-    """Build CompareOptions from saved preferences overlaid with query params."""
-    prefs = merge_preferences(user.get("preferences", {}))
-    qp = request.query_params
-
-    # When the filter form is submitted it includes a hidden `filters_active`
-    # marker. An off checkbox — or a list filter with everything deselected —
-    # sends no value, so without this marker we can't tell "user cleared it"
-    # from "not specified". When the form was submitted, an absent value means
-    # empty/off; on a bare page load, fall back to the saved preference.
-    form_submitted = "filters_active" in qp
-
-    def flag(name: str, default: bool) -> bool:
-        if name in qp:
-            return qp[name] in ("true", "on", "1")
-        return False if form_submitted else default
-
-    def multi(name: str, default: list[str]) -> list[str]:
-        values = qp.getlist(name)
-        if values or form_submitted:
-            return values
-        return default
-
-    # User selection: checked `user` boxes win. On a bare load fall back to the
-    # saved preference, expanding the "all" sentinel to every known user.
-    selected: list[str] = qp.getlist("user")
-    if not selected and not form_submitted:
-        pref_users = prefs["selected_users"]
-        if pref_users == "all":
-            selected = [
-                str(u["user_id"]) for u in get_repo().scan_users() if u.get("user_id")
-            ]
-        else:
-            selected = list(pref_users)
-
-    view = qp.get("view", prefs["default_view"])
-    return CompareOptions(
-        selected_user_ids=selected,
-        include_single_player=flag("single_player", prefs["include_single_player"]),
-        installed_only=flag("installed_only", prefs["installed_only"]),
-        exclude_platforms=multi("exclude", prefs["exclude_platforms"]),
-        exclusive=flag("exclusive", prefs["exclusive"]),
-        all_games=view == "grid",
-        randomize=flag("randomize", False),
-        show_keys=flag("show_keys", prefs["show_keys"]),
-        sort=qp.get("sort", "title"),
-        direction=qp.get("dir", "asc"),
-    )
+def _parse_options(
+    request: Request,
+    user: dict,
+    repo: Repository | None = None,
+) -> WebCompareOptions:
+    """Build web options from saved preferences overlaid with query params."""
+    return web.parse_options(request, user, repo or get_repo())
 
 
-def _maybe_enrich(repo: Repository, opts: CompareOptions) -> str | None:
+def _maybe_enrich(repo: Repository, opts: WebCompareOptions) -> str | None:
     """Find stale/pending games among the selected libraries and enqueue a job.
 
     If a job is already pending or running, return its id rather than
     creating a duplicate — each /games page load would otherwise queue a
     new batch of the same games, exhausting Lambda concurrency.
     """
-    active = repo.get_active_job()
-    if active:
-        return active["job_id"]
-
-    settings = get_settings()
-    cutoff = datetime.now(timezone.utc) - timedelta(days=settings.igdb_stale_days)
-
-    release_keys: set[str] = set()
-    for user_id in opts.selected_user_ids:
-        for entry in repo.get_user_library(user_id):
-            release_keys.add(entry["release_key"])
-
-    stale: list[str] = []
-    for rk, game in repo.batch_get_games(release_keys).items():
-        status = game.get("enrichment_status")
-        if status in (ENRICHMENT_PENDING, None):
-            stale.append(rk)
-            continue
-        enriched_at = game.get("enriched_at")
-        if enriched_at and parse_iso(enriched_at) < cutoff:
-            stale.append(rk)
-
-    if not stale:
-        return None
-    return create_enrichment_job(repo, get_queue(), stale)
+    advice = service.ensure_enrichment_job(repo, get_queue(), opts.to_query())
+    return advice.job_id
 
 
 @router.get("/games", response_class=HTMLResponse)
@@ -121,18 +55,18 @@ def games_page(
     user: dict = Depends(current_user),
     repo: Repository = Depends(get_repo),
 ):
-    opts = _parse_options(request, user)
+    opts = _parse_options(request, user, repo)
     job_id = _maybe_enrich(repo, opts)
-    result = service.compare(repo, opts)
-    caption = service.build_caption(repo, opts, result)
     users = {str(u["user_id"]): u for u in repo.scan_users() if u.get("user_id")}
+    result = service.compare(repo, opts.to_query())
+    caption = web.build_caption(users, opts, result)
     return templates.TemplateResponse(
         request,
         "games.html.jinja",
         {
             "user": user,
             "users": users,
-            "games": result.games,
+            "games": web.present_games(result, opts),
             "caption": caption,
             "opts": opts,
             "prefs": merge_preferences(user.get("preferences", {})),
@@ -149,21 +83,34 @@ def games_table(
     user: dict = Depends(current_user_api),
     repo: Repository = Depends(get_repo),
 ):
-    opts = _parse_options(request, user)
-    result = service.compare(repo, opts)
-    caption = service.build_caption(repo, opts, result)
     users = {str(u["user_id"]): u for u in repo.scan_users() if u.get("user_id")}
+    opts = _parse_options(request, user, repo)
+    result = service.compare(repo, opts.to_query())
+    caption = web.build_caption(users, opts, result)
     return templates.TemplateResponse(
         request,
         "games_table.html.jinja",
         {
             "users": users,
-            "games": result.games,
+            "games": web.present_games(result, opts),
             "caption": caption,
             "opts": opts,
             "is_grid": opts.all_games,
         },
     )
+
+
+@router.get("/api/games")
+def games_api(
+    request: Request,
+    user: dict = Depends(current_user_api),
+    repo: Repository = Depends(get_repo),
+):
+    """Return the comparison dataset as JSON for headless consumers."""
+    opts = _parse_options(request, user, repo)
+    query = opts.to_query()
+    result = service.compare(repo, query)
+    return JSONResponse(api.serialize_comparison(query, result))
 
 
 @router.get("/api/jobs/{job_id}", response_class=HTMLResponse)

--- a/src/gamatrix/games/service.py
+++ b/src/gamatrix/games/service.py
@@ -1,58 +1,111 @@
-"""Compute the displayed game list from stored libraries and metadata.
+"""UX-neutral comparison and refresh-planning services.
 
-This is the v2 equivalent of v1's gogDB.get_common_games / merge_duplicate_titles
-/ filter_games, but it reads from DynamoDB instead of opening SQLite DBs, and it
-returns a sorted list of plain dicts that the templates (and column sorting) can
-consume directly.
+This module owns the application-layer contract for comparing libraries from the
+stored read model. It returns typed comparison items and keeps presentation
+concerns such as captions, random selection, and template context outside the
+core service so the same data contract can drive multiple UX layers.
 """
 
 from __future__ import annotations
 
-import random
-from dataclasses import dataclass, field
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Iterable, Literal, Protocol
 
-from gamatrix.constants import IGDB_MULTIPLAYER_GAME_MODES, PLATFORMS
+from gamatrix.config import Settings, get_settings
+from gamatrix.constants import (
+    ENRICHMENT_PENDING,
+    IGDB_MULTIPLAYER_GAME_MODES,
+    PLATFORMS,
+)
+from gamatrix.helpers import parse_iso
+from gamatrix.jobs import create_enrichment_job
 from gamatrix.storage.dynamo import Repository
+from gamatrix.storage.queue import EnrichmentQueue
 
 
 @dataclass
-class CompareOptions:
+class SortSpec:
+    field: str = "title"
+    direction: Literal["asc", "desc"] = "asc"
+
+
+@dataclass
+class ComparisonQuery:
     selected_user_ids: list[str] = field(default_factory=list)
     include_single_player: bool = False
     installed_only: bool = False
     exclude_platforms: list[str] = field(default_factory=list)
     exclusive: bool = False
-    all_games: bool = False  # grid view: list everything owned, no intersection
-    randomize: bool = False
-    show_keys: bool = False  # show each game's GOG release key as an extra column
-    sort: str = "title"
-    direction: str = "asc"
+    scope: Literal["shared", "owned"] = "shared"
+    sort: SortSpec = field(default_factory=SortSpec)
 
 
-# Sortable columns -> key function over a game dict.
+class ComparisonRepository(Protocol):
+    """Read-model operations the comparison service needs."""
+
+    def scan_users(self) -> list[dict]: ...
+
+    def get_user_library(self, user_id: str) -> list[dict]: ...
+
+    def batch_get_games(self, release_keys: Iterable[str]) -> dict[str, dict]: ...
+
+    def get_all_metadata(self) -> dict[str, dict]: ...
+
+
+# Sortable columns -> key function over a comparison item.
 SORT_KEYS = {
-    "title": lambda g: g["slug"],
-    "players": lambda g: g.get("max_players", 0),
-    "rating": lambda g: g.get("rating", 0),
-    "installed": lambda g: len(g.get("installed", [])),
+    "title": lambda g: g.slug,
+    "players": lambda g: g.max_players,
+    "rating": lambda g: g.rating,
+    "installed": lambda g: len(g.installed),
 }
 
 
 @dataclass
-class CompareResult:
-    games: list[dict]
+class ComparisonItem:
+    release_key: str
+    title: str
+    slug: str
+    igdb_key: str
+    platforms: list[str]
+    owners: list[str]
+    installed: list[str]
+    max_players: int
+    multiplayer: bool
+    rating: int | float
+    rating_count: int = 0
+    enrichment_status: str | None = None
+    comment: str = ""
+    url: str | None = None
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+@dataclass
+class ComparisonDataset:
+    items: list[ComparisonItem]
     excluded_user_ids: list[str]
     total: int
 
 
-def compare(repo: Repository, opts: CompareOptions) -> CompareResult:
+@dataclass
+class RefreshAdvice:
+    job_id: str | None
+    stale_release_keys: list[str] = field(default_factory=list)
+    reused_active_job: bool = False
+    created_job: bool = False
+
+
+def compare(repo: ComparisonRepository, query: ComparisonQuery) -> ComparisonDataset:
     users = {str(u["user_id"]): u for u in repo.scan_users() if u.get("user_id")}
-    selected = [str(u) for u in opts.selected_user_ids if str(u) in users]
+    selected = [str(u) for u in query.selected_user_ids if str(u) in users]
 
     # For exclusive mode we need to know who else owns each game.
     excluded_ids: list[str] = []
     libraries_needed = set(selected)
-    if opts.exclusive:
+    if query.exclusive:
         excluded_ids = [u for u in users if u not in selected]
         libraries_needed.update(excluded_ids)
 
@@ -62,7 +115,7 @@ def compare(repo: Repository, opts: CompareOptions) -> CompareResult:
         for entry in repo.get_user_library(user_id):
             rk = entry["release_key"]
             platform = entry.get("platform", rk.split("_")[0])
-            if platform in opts.exclude_platforms:
+            if platform in query.exclude_platforms:
                 continue
             slot = agg.setdefault(
                 rk, {"owners": set(), "installed": set(), "platform": platform}
@@ -74,7 +127,7 @@ def compare(repo: Repository, opts: CompareOptions) -> CompareResult:
     metadata = repo.batch_get_games(agg.keys())
     overrides = repo.get_all_metadata()
 
-    games: list[dict] = []
+    games: list[ComparisonItem] = []
     for rk, slot in agg.items():
         meta = metadata.get(rk)
         if meta is None:
@@ -83,53 +136,50 @@ def compare(repo: Repository, opts: CompareOptions) -> CompareResult:
         games.append(game)
 
     games = _merge_duplicates(games)
-    games = _filter(games, opts, selected, excluded_ids)
+    games = _filter(games, query, selected, excluded_ids)
     games.sort(
-        key=SORT_KEYS.get(opts.sort, SORT_KEYS["title"]),
-        reverse=opts.direction == "desc",
+        key=SORT_KEYS.get(query.sort.field, SORT_KEYS["title"]),
+        reverse=query.sort.direction == "desc",
     )
 
     # Count unique games, not rows: the grid view can list the same title on
     # more than one row when platform copies have different owners, but those
     # are still one game. Rows are already grouped by slug, so distinct slugs
     # is the unique-game count.
-    total = len({g["slug"] for g in games})
-    if opts.randomize and games:
-        games = [random.choice(games)]
+    total = len({g.slug for g in games})
 
-    return CompareResult(games=games, excluded_user_ids=excluded_ids, total=total)
+    return ComparisonDataset(items=games, excluded_user_ids=excluded_ids, total=total)
 
 
-def _build_game(rk: str, slot: dict, meta: dict, overrides: dict) -> dict:
-    game = {
-        "release_key": rk,
-        "title": meta.get("title", rk),
-        "slug": meta.get("slug", ""),
-        "igdb_key": meta.get("igdb_key", rk),
-        "platforms": [slot["platform"]],
-        "owners": sorted(slot["owners"]),
-        "installed": sorted(slot["installed"]),
-        "max_players": meta.get("max_players", 0),
-        "multiplayer": meta.get("multiplayer", False),
-        "rating": meta.get("rating", 0),
-        "rating_count": meta.get("rating_count", 0),
-        "enrichment_status": meta.get("enrichment_status"),
-        "comment": "",
-        "url": None,
-    }
+def _build_game(rk: str, slot: dict, meta: dict, overrides: dict) -> ComparisonItem:
+    game = ComparisonItem(
+        release_key=rk,
+        title=meta.get("title", rk),
+        slug=meta.get("slug", ""),
+        igdb_key=meta.get("igdb_key", rk),
+        platforms=[slot["platform"]],
+        owners=sorted(slot["owners"]),
+        installed=sorted(slot["installed"]),
+        max_players=meta.get("max_players", 0),
+        multiplayer=meta.get("multiplayer", False),
+        rating=meta.get("rating", 0),
+        rating_count=meta.get("rating_count", 0),
+        enrichment_status=meta.get("enrichment_status"),
+    )
 
     # Apply manual overrides (config metadata in v1) by slug; these win over IGDB.
-    override = overrides.get(game["slug"])
+    override = overrides.get(game.slug)
     if override:
         if "max_players" in override:
-            game["max_players"] = override["max_players"]
-            game["multiplayer"] = _multiplayer(
-                override["max_players"], meta.get("game_modes", [])
+            game.max_players = override["max_players"]
+            game.multiplayer = _multiplayer(
+                override["max_players"],
+                meta.get("game_modes", []),
             )
         if override.get("comment"):
-            game["comment"] = override["comment"]
+            game.comment = override["comment"]
         if override.get("url"):
-            game["url"] = override["url"]
+            game.url = override["url"]
     return game
 
 
@@ -139,32 +189,32 @@ def _multiplayer(max_players: int, game_modes: list[int]) -> bool:
     return any(m in IGDB_MULTIPLAYER_GAME_MODES for m in game_modes)
 
 
-def _merge_duplicates(games: list[dict]) -> list[dict]:
+def _merge_duplicates(games: list[ComparisonItem]) -> list[ComparisonItem]:
     """Merge same-title entries that have identical owners (cross-platform copies).
 
     Mirrors v1: copies of the same game on different stores held by the same set
     of owners collapse into one row listing all platforms; copies owned by
     different people stay separate.
     """
-    grouped: dict[tuple[str, frozenset], dict] = {}
+    grouped: dict[tuple[str, frozenset[str]], ComparisonItem] = {}
     for game in games:
-        key = (game["slug"], frozenset(game["owners"]))
+        key = (game.slug, frozenset(game.owners))
         if key not in grouped:
-            grouped[key] = {**game, "platforms": list(game["platforms"])}
+            grouped[key] = ComparisonItem(
+                **{**game.to_dict(), "platforms": list(game.platforms)}
+            )
             continue
         existing = grouped[key]
-        for platform in game["platforms"]:
-            if platform not in existing["platforms"]:
-                existing["platforms"].append(platform)
-        existing["installed"] = sorted(
-            set(existing["installed"]) | set(game["installed"])
-        )
-        existing["max_players"] = max(existing["max_players"], game["max_players"])
-        existing["multiplayer"] = existing["multiplayer"] or game["multiplayer"]
-        existing["rating"] = max(existing["rating"], game["rating"])
+        for platform in game.platforms:
+            if platform not in existing.platforms:
+                existing.platforms.append(platform)
+        existing.installed = sorted(set(existing.installed) | set(game.installed))
+        existing.max_players = max(existing.max_players, game.max_players)
+        existing.multiplayer = existing.multiplayer or game.multiplayer
+        existing.rating = max(existing.rating, game.rating)
 
     for game in grouped.values():
-        game["platforms"] = _sort_platforms(game["platforms"])
+        game.platforms = _sort_platforms(game.platforms)
     return list(grouped.values())
 
 
@@ -176,56 +226,76 @@ def _sort_platforms(platforms: list[str]) -> list[str]:
 
 
 def _filter(
-    games: list[dict],
-    opts: CompareOptions,
+    games: list[ComparisonItem],
+    query: ComparisonQuery,
     selected: list[str],
     excluded_ids: list[str],
-) -> list[dict]:
+) -> list[ComparisonItem]:
     selected_set = set(selected)
     excluded_set = set(excluded_ids)
     result = []
     for game in games:
-        if not opts.include_single_player and not game["multiplayer"]:
+        if not query.include_single_player and not game.multiplayer:
             continue
-        if not opts.all_games:
-            owners = set(game["owners"])
+        if query.scope == "shared":
+            owners = set(game.owners)
             if not selected_set.issubset(owners):
                 continue
-            if opts.installed_only and not selected_set.issubset(
-                set(game["installed"])
-            ):
+            if query.installed_only and not selected_set.issubset(set(game.installed)):
                 continue
-            if opts.exclusive and owners & excluded_set:
+            if query.exclusive and owners & excluded_set:
                 continue
         result.append(game)
     return result
 
 
-def build_caption(repo: Repository, opts: CompareOptions, result: CompareResult) -> str:
-    users = {str(u["user_id"]): u for u in repo.scan_users() if u.get("user_id")}
-    names = [users[u]["username"] for u in opts.selected_user_ids if u in users]
+def ensure_enrichment_job(
+    repo: Repository,
+    queue: EnrichmentQueue,
+    query: ComparisonQuery,
+    settings: Settings | None = None,
+) -> RefreshAdvice:
+    """Ensure the selected libraries have an active refresh job if needed."""
+    active = repo.get_active_job()
+    if active:
+        return RefreshAdvice(
+            job_id=active["job_id"],
+            reused_active_job=True,
+        )
 
-    if opts.randomize:
-        start = f"Random game selected from {result.total}"
-    else:
-        start = str(result.total)
+    stale = stale_release_keys(repo, query, settings=settings)
+    if not stale:
+        return RefreshAdvice(job_id=None, stale_release_keys=[])
 
-    if opts.all_games:
-        middle = "total games owned by"
-    elif len(opts.selected_user_ids) == 1:
-        middle = "games owned by"
-    else:
-        middle = "games in common between"
+    job_id = create_enrichment_job(repo, queue, stale)
+    return RefreshAdvice(
+        job_id=job_id,
+        stale_release_keys=stale,
+        created_job=job_id is not None,
+    )
 
-    caption = f"{start} {middle} {', '.join(names)}"
 
-    if opts.exclusive and result.excluded_user_ids and not opts.all_games:
-        excluded_names = [
-            users[u]["username"] for u in result.excluded_user_ids if u in users
-        ]
-        caption += f" and not owned by {', '.join(excluded_names)}"
-    if opts.exclude_platforms:
-        caption += f" ({', '.join(opts.exclude_platforms).title()} excluded)"
-    if opts.installed_only and not opts.all_games:
-        caption += " (installed only)"
-    return caption
+def stale_release_keys(
+    repo: Repository,
+    query: ComparisonQuery,
+    settings: Settings | None = None,
+) -> list[str]:
+    """Return selected-library games whose enrichment is pending or stale."""
+    settings = settings or get_settings()
+    cutoff = datetime.now(timezone.utc) - timedelta(days=settings.igdb_stale_days)
+
+    release_keys: set[str] = set()
+    for user_id in query.selected_user_ids:
+        for entry in repo.get_user_library(user_id):
+            release_keys.add(entry["release_key"])
+
+    stale: list[str] = []
+    for rk, game in repo.batch_get_games(release_keys).items():
+        status = game.get("enrichment_status")
+        if status in (ENRICHMENT_PENDING, None):
+            stale.append(rk)
+            continue
+        enriched_at = game.get("enriched_at")
+        if enriched_at and parse_iso(enriched_at) < cutoff:
+            stale.append(rk)
+    return stale

--- a/src/gamatrix/games/service.py
+++ b/src/gamatrix/games/service.py
@@ -8,7 +8,7 @@ core service so the same data contract can drive multiple UX layers.
 
 from __future__ import annotations
 
-from dataclasses import asdict, dataclass, field
+from dataclasses import asdict, dataclass, field, replace
 from datetime import datetime, timedelta, timezone
 from typing import Iterable, Literal, Protocol
 
@@ -100,6 +100,7 @@ class RefreshAdvice:
 
 def compare(repo: ComparisonRepository, query: ComparisonQuery) -> ComparisonDataset:
     users = {str(u["user_id"]): u for u in repo.scan_users() if u.get("user_id")}
+
     selected = [str(u) for u in query.selected_user_ids if str(u) in users]
 
     # For exclusive mode we need to know who else owns each game.
@@ -200,9 +201,7 @@ def _merge_duplicates(games: list[ComparisonItem]) -> list[ComparisonItem]:
     for game in games:
         key = (game.slug, frozenset(game.owners))
         if key not in grouped:
-            grouped[key] = ComparisonItem(
-                **{**game.to_dict(), "platforms": list(game.platforms)}
-            )
+            grouped[key] = replace(game, platforms=list(game.platforms))
             continue
         existing = grouped[key]
         for platform in game.platforms:

--- a/src/gamatrix/games/web.py
+++ b/src/gamatrix/games/web.py
@@ -1,0 +1,154 @@
+"""Web adapter and presenter for the games comparison UX.
+
+This layer translates FastAPI request and preference semantics into the
+application-layer comparison query, then shapes typed comparison results back
+into the current Jinja template contract. The existing web UX stays intact
+without forcing the comparison service to depend on Jinja/HTMX concerns.
+"""
+
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass, field
+from typing import Literal
+
+from fastapi import Request
+
+from gamatrix.games.preferences import merge_preferences
+from gamatrix.games.service import (
+    ComparisonDataset,
+    ComparisonQuery,
+    ComparisonRepository,
+    SortSpec,
+)
+
+
+@dataclass
+class WebCompareOptions:
+    selected_user_ids: list[str] = field(default_factory=list)
+    include_single_player: bool = False
+    installed_only: bool = False
+    exclude_platforms: list[str] = field(default_factory=list)
+    exclusive: bool = False
+    view: Literal["list", "grid"] = "list"
+    randomize: bool = False
+    show_keys: bool = False
+    sort: str = "title"
+    direction: Literal["asc", "desc"] = "asc"
+
+    @property
+    def all_games(self) -> bool:
+        return self.view == "grid"
+
+    def to_query(self) -> ComparisonQuery:
+        return ComparisonQuery(
+            selected_user_ids=list(self.selected_user_ids),
+            include_single_player=self.include_single_player,
+            installed_only=self.installed_only,
+            exclude_platforms=list(self.exclude_platforms),
+            exclusive=self.exclusive,
+            scope="owned" if self.all_games else "shared",
+            sort=SortSpec(field=self.sort, direction=self.direction),
+        )
+
+
+def parse_options(
+    request: Request,
+    user: dict,
+    repo: ComparisonRepository,
+) -> WebCompareOptions:
+    """Build web options from saved preferences overlaid with query params."""
+    prefs = merge_preferences(user.get("preferences", {}))
+    qp = request.query_params
+
+    # When the filter form is submitted it includes a hidden `filters_active`
+    # marker. An off checkbox — or a list filter with everything deselected —
+    # sends no value, so without this marker we can't tell "user cleared it"
+    # from "not specified". When the form was submitted, an absent value means
+    # empty/off; on a bare page load, fall back to the saved preference.
+    form_submitted = "filters_active" in qp
+
+    def flag(name: str, default: bool) -> bool:
+        if name in qp:
+            return qp[name] in ("true", "on", "1")
+        return False if form_submitted else default
+
+    def multi(name: str, default: list[str]) -> list[str]:
+        values = qp.getlist(name)
+        if values or form_submitted:
+            return values
+        return default
+
+    # User selection: checked `user` boxes win. On a bare load fall back to the
+    # saved preference, expanding the "all" sentinel to every known user.
+    selected: list[str] = qp.getlist("user")
+    if not selected and not form_submitted:
+        pref_users = prefs["selected_users"]
+        if pref_users == "all":
+            selected = [
+                str(u["user_id"]) for u in repo.scan_users() if u.get("user_id")
+            ]
+        else:
+            selected = list(pref_users)
+
+    view = qp.get("view", prefs["default_view"])
+    if view not in ("list", "grid"):
+        view = "list"
+    direction: Literal["asc", "desc"] = (
+        "desc" if qp.get("dir", "asc") == "desc" else "asc"
+    )
+
+    return WebCompareOptions(
+        selected_user_ids=selected,
+        include_single_player=flag("single_player", prefs["include_single_player"]),
+        installed_only=flag("installed_only", prefs["installed_only"]),
+        exclude_platforms=multi("exclude", prefs["exclude_platforms"]),
+        exclusive=flag("exclusive", prefs["exclusive"]),
+        view=view,
+        randomize=flag("randomize", False),
+        show_keys=flag("show_keys", prefs["show_keys"]),
+        sort=qp.get("sort", "title"),
+        direction=direction,
+    )
+
+
+def present_games(dataset: ComparisonDataset, opts: WebCompareOptions) -> list[dict]:
+    """Convert typed comparison items into the current template payload."""
+    games = [item.to_dict() for item in dataset.items]
+    if opts.randomize and games:
+        return [random.choice(games)]
+    return games
+
+
+def build_caption(
+    users: dict[str, dict],
+    opts: WebCompareOptions,
+    dataset: ComparisonDataset,
+) -> str:
+    """Build the current English caption for the web UX."""
+    names = [users[u]["username"] for u in opts.selected_user_ids if u in users]
+
+    if opts.randomize:
+        start = f"Random game selected from {dataset.total}"
+    else:
+        start = str(dataset.total)
+
+    if opts.all_games:
+        middle = "total games owned by"
+    elif len(opts.selected_user_ids) == 1:
+        middle = "games owned by"
+    else:
+        middle = "games in common between"
+
+    caption = f"{start} {middle} {', '.join(names)}"
+
+    if opts.exclusive and dataset.excluded_user_ids and not opts.all_games:
+        excluded_names = [
+            users[u]["username"] for u in dataset.excluded_user_ids if u in users
+        ]
+        caption += f" and not owned by {', '.join(excluded_names)}"
+    if opts.exclude_platforms:
+        caption += f" ({', '.join(opts.exclude_platforms).title()} excluded)"
+    if opts.installed_only and not opts.all_games:
+        caption += " (installed only)"
+    return caption

--- a/tests/test_games.py
+++ b/tests/test_games.py
@@ -134,7 +134,103 @@ def test_merge_cross_platform_duplicates(repo):
     )
     result = compare(repo, ComparisonQuery(selected_user_ids=["1"]))
     assert len(result.items) == 1
-    assert sorted(result.items[0].platforms) == ["gog", "steam"]
+    assert result.items[0].platforms == ["steam", "gog"]
+
+
+def test_merge_cross_platform_duplicates_union_installed_and_keep_best_metadata(repo):
+    repo.put_user({"email": "a@x.com", "username": "A", "user_id": "1"})
+    repo.put_user({"email": "b@x.com", "username": "B", "user_id": "2"})
+    for rk, platform, multiplayer, max_players, rating in [
+        ("epic_50", "epic", False, 1, 40),
+        ("steam_51", "steam", True, 4, 90),
+        ("gog_52", "gog", True, 8, 75),
+    ]:
+        repo.put_game(
+            {
+                "release_key": rk,
+                "title": "Merged Game",
+                "slug": "mergedgame",
+                "igdb_key": rk,
+                "platform": platform,
+                "multiplayer": multiplayer,
+                "max_players": max_players,
+                "rating": rating,
+                "game_modes": [],
+                "enrichment_status": "done",
+            }
+        )
+    repo.replace_user_library(
+        "1",
+        [
+            {"release_key": "epic_50", "platform": "epic", "installed": False},
+            {"release_key": "steam_51", "platform": "steam", "installed": True},
+            {"release_key": "gog_52", "platform": "gog", "installed": False},
+        ],
+    )
+    repo.replace_user_library(
+        "2",
+        [
+            {"release_key": "epic_50", "platform": "epic", "installed": False},
+            {"release_key": "steam_51", "platform": "steam", "installed": False},
+            {"release_key": "gog_52", "platform": "gog", "installed": True},
+        ],
+    )
+
+    result = compare(repo, ComparisonQuery(selected_user_ids=["1", "2"]))
+
+    assert len(result.items) == 1
+    merged = result.items[0]
+    assert merged.platforms == ["steam", "gog", "epic"]
+    assert merged.installed == ["1", "2"]
+    assert merged.max_players == 8
+    assert merged.multiplayer is True
+    assert merged.rating == 90
+
+
+def test_same_slug_merges_only_within_matching_owner_groups(repo):
+    repo.put_user({"email": "a@x.com", "username": "A", "user_id": "1"})
+    repo.put_user({"email": "b@x.com", "username": "B", "user_id": "2"})
+    for rk, platform in [
+        ("steam_60", "steam"),
+        ("gog_61", "gog"),
+        ("epic_62", "epic"),
+    ]:
+        repo.put_game(
+            {
+                "release_key": rk,
+                "title": "Grouped Game",
+                "slug": "groupedgame",
+                "igdb_key": rk,
+                "platform": platform,
+                "multiplayer": True,
+                "max_players": 4,
+                "rating": 0,
+                "game_modes": [],
+                "enrichment_status": "done",
+            }
+        )
+    repo.replace_user_library(
+        "1",
+        [
+            {"release_key": "steam_60", "platform": "steam", "installed": False},
+            {"release_key": "gog_61", "platform": "gog", "installed": False},
+        ],
+    )
+    repo.replace_user_library(
+        "2", [{"release_key": "epic_62", "platform": "epic", "installed": False}]
+    )
+
+    result = compare(
+        repo,
+        ComparisonQuery(selected_user_ids=["1", "2"], scope="owned"),
+    )
+
+    assert result.total == 1
+    rows = {(tuple(game.owners), tuple(game.platforms)) for game in result.items}
+    assert rows == {
+        (("1",), ("steam", "gog")),
+        (("2",), ("epic",)),
+    }
 
 
 def test_count_is_unique_games_not_rows(repo):

--- a/tests/test_games.py
+++ b/tests/test_games.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from gamatrix.games.service import CompareOptions, compare
+from gamatrix.games.service import ComparisonQuery, SortSpec, compare
 from gamatrix.helpers import now_iso
 
 
@@ -53,45 +53,48 @@ def populated(repo):
 
 
 def test_common_multiplayer_games(populated):
-    result = compare(populated, CompareOptions(selected_user_ids=["1", "2"]))
-    titles = {g["title"] for g in result.games}
+    result = compare(populated, ComparisonQuery(selected_user_ids=["1", "2"]))
+    titles = {g.title for g in result.items}
     assert titles == {"Coop Game", "Shared MP"}
 
 
 def test_include_single_player_single_user(populated):
     result = compare(
         populated,
-        CompareOptions(selected_user_ids=["1"], include_single_player=True),
+        ComparisonQuery(selected_user_ids=["1"], include_single_player=True),
     )
-    titles = {g["title"] for g in result.games}
+    titles = {g.title for g in result.items}
     assert titles == {"Coop Game", "Solo Game", "Shared MP"}
 
 
 def test_installed_only(populated):
     result = compare(
         populated,
-        CompareOptions(selected_user_ids=["1"], installed_only=True),
+        ComparisonQuery(selected_user_ids=["1"], installed_only=True),
     )
     # Only steam_10 is installed by user 1 (and it's multiplayer).
-    titles = {g["title"] for g in result.games}
+    titles = {g.title for g in result.items}
     assert titles == {"Coop Game"}
 
 
 def test_exclude_platform(populated):
     result = compare(
         populated,
-        CompareOptions(selected_user_ids=["1", "2"], exclude_platforms=["gog"]),
+        ComparisonQuery(selected_user_ids=["1", "2"], exclude_platforms=["gog"]),
     )
-    titles = {g["title"] for g in result.games}
+    titles = {g.title for g in result.items}
     assert titles == {"Coop Game"}
 
 
 def test_sort_by_rating_desc(populated):
     result = compare(
         populated,
-        CompareOptions(selected_user_ids=["1", "2"], sort="rating", direction="desc"),
+        ComparisonQuery(
+            selected_user_ids=["1", "2"],
+            sort=SortSpec(field="rating", direction="desc"),
+        ),
     )
-    ratings = [g["rating"] for g in result.games]
+    ratings = [g.rating for g in result.items]
     assert ratings == sorted(ratings, reverse=True)
 
 
@@ -99,10 +102,10 @@ def test_metadata_override_applied(populated):
     populated.put_metadata(
         {"slug": "coopgame", "max_players": 2, "comment": "Use Hamachi"}
     )
-    result = compare(populated, CompareOptions(selected_user_ids=["1", "2"]))
-    coop = next(g for g in result.games if g["slug"] == "coopgame")
-    assert coop["max_players"] == 2
-    assert coop["comment"] == "Use Hamachi"
+    result = compare(populated, ComparisonQuery(selected_user_ids=["1", "2"]))
+    coop = next(g for g in result.items if g.slug == "coopgame")
+    assert coop.max_players == 2
+    assert coop.comment == "Use Hamachi"
 
 
 def test_merge_cross_platform_duplicates(repo):
@@ -129,9 +132,9 @@ def test_merge_cross_platform_duplicates(repo):
             {"release_key": "gog_31", "platform": "gog", "installed": False},
         ],
     )
-    result = compare(repo, CompareOptions(selected_user_ids=["1"]))
-    assert len(result.games) == 1
-    assert sorted(result.games[0]["platforms"]) == ["gog", "steam"]
+    result = compare(repo, ComparisonQuery(selected_user_ids=["1"]))
+    assert len(result.items) == 1
+    assert sorted(result.items[0].platforms) == ["gog", "steam"]
 
 
 def test_count_is_unique_games_not_rows(repo):
@@ -165,6 +168,22 @@ def test_count_is_unique_games_not_rows(repo):
     repo.replace_user_library(
         "2", [{"release_key": "gog_41", "platform": "gog", "installed": False}]
     )
-    result = compare(repo, CompareOptions(selected_user_ids=["1", "2"], all_games=True))
-    assert len(result.games) == 2  # two rows
+    result = compare(
+        repo,
+        ComparisonQuery(selected_user_ids=["1", "2"], scope="owned"),
+    )
+    assert len(result.items) == 2  # two rows
     assert result.total == 1  # but one unique game
+
+
+def test_owned_scope_lists_all_selected_users_games(populated):
+    result = compare(
+        populated,
+        ComparisonQuery(
+            selected_user_ids=["1", "2"],
+            scope="owned",
+            include_single_player=True,
+        ),
+    )
+    titles = {g.title for g in result.items}
+    assert titles == {"Coop Game", "Solo Game", "Shared MP"}

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -10,14 +10,18 @@ from __future__ import annotations
 
 import types
 
+from fastapi.testclient import TestClient
 from starlette.datastructures import QueryParams
 
-from gamatrix.games import routes
+from gamatrix.app import app
+from gamatrix.auth.dependencies import current_user_api, get_repo
+from gamatrix.games import routes, web
 
 
 def _opts(query_string: str, preferences: dict):
     request = types.SimpleNamespace(query_params=QueryParams(query_string))
-    return routes._parse_options(request, {"preferences": preferences})
+    repo = types.SimpleNamespace(scan_users=lambda: [])
+    return routes._parse_options(request, {"preferences": preferences}, repo)
 
 
 def test_unchecked_box_overrides_saved_on_preference():
@@ -88,3 +92,85 @@ def test_bare_load_uses_saved_user_selection():
     prefs = {"selected_users": ["1", "2"], "exclude_platforms": []}
     opts = _opts("", prefs)
     assert opts.selected_user_ids == ["1", "2"]
+
+
+def test_invalid_presentation_options_fall_back_to_safe_values():
+    opts = _opts("view=unknown&dir=sideways", {})
+    assert opts.view == "list"
+    assert opts.direction == "asc"
+
+
+def test_present_games_randomizes_only_in_web_layer():
+    dataset = types.SimpleNamespace(
+        items=[
+            types.SimpleNamespace(to_dict=lambda: {"title": "A"}),
+            types.SimpleNamespace(to_dict=lambda: {"title": "B"}),
+        ]
+    )
+    opts = web.WebCompareOptions(randomize=True)
+    games = web.present_games(dataset, opts)
+    assert len(games) == 1
+    assert games[0]["title"] in {"A", "B"}
+
+
+def test_api_games_returns_headless_dataset(repo):
+    repo.put_user({"email": "viewer@x.com", "username": "Viewer", "user_id": "99"})
+    repo.put_user({"email": "a@x.com", "username": "A", "user_id": "1"})
+    repo.put_user({"email": "b@x.com", "username": "B", "user_id": "2"})
+    repo.put_game(
+        {
+            "release_key": "steam_10",
+            "title": "Coop Game",
+            "slug": "coopgame",
+            "igdb_key": "steam_10",
+            "platform": "steam",
+            "multiplayer": True,
+            "max_players": 4,
+            "rating": 90,
+            "game_modes": [],
+            "enrichment_status": "done",
+        }
+    )
+    repo.replace_user_library(
+        "1",
+        [{"release_key": "steam_10", "platform": "steam", "installed": True}],
+    )
+    repo.replace_user_library(
+        "2",
+        [{"release_key": "steam_10", "platform": "steam", "installed": False}],
+    )
+
+    app.dependency_overrides[get_repo] = lambda: repo
+    app.dependency_overrides[current_user_api] = lambda: {
+        "email": "viewer@x.com",
+        "username": "Viewer",
+    }
+    try:
+        client = TestClient(app)
+        response = client.get("/api/games?user=1&user=2")
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["query"]["scope"] == "shared"
+    assert payload["total"] == 1
+    assert payload["games"][0]["title"] == "Coop Game"
+
+
+def test_authenticated_ux_routes_remain_auth_gated(repo):
+    app.dependency_overrides[get_repo] = lambda: repo
+    try:
+        client = TestClient(app)
+        for path in ("/games", "/preferences", "/upload", "/auth/passkeys"):
+            response = client.get(path, follow_redirects=False)
+            assert response.status_code == 302
+            assert response.headers["location"] == "/auth/login"
+
+        for path in ("/games/table", "/api/games", "/api/jobs/not-found"):
+            assert client.get(path).status_code == 401
+
+        for path in ("/games/refresh-igdb", "/games/refresh-igdb-all"):
+            assert client.post(path).status_code == 401
+    finally:
+        app.dependency_overrides.clear()

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,6 +1,6 @@
 """Tests for request-option parsing in the games routes.
 
-Focus on how `_parse_options` resolves boolean filter checkboxes. An unchecked
+Focus on how `web.parse_options` resolves boolean filter checkboxes. An unchecked
 HTML checkbox submits no value, so the filter form sends a hidden
 `filters_active` marker; when present, an absent flag means "off" rather than
 falling back to the user's saved preference.
@@ -21,7 +21,7 @@ from gamatrix.games import routes, web
 def _opts(query_string: str, preferences: dict):
     request = types.SimpleNamespace(query_params=QueryParams(query_string))
     repo = types.SimpleNamespace(scan_users=lambda: [])
-    return routes._parse_options(request, {"preferences": preferences}, repo)
+    return web.parse_options(request, {"preferences": preferences}, repo)
 
 
 def test_unchecked_box_overrides_saved_on_preference():


### PR DESCRIPTION
_Change [1 / 3] to get updated UX in place for Gamatrix: [Preview of the hotness is here](https://github.com/user-attachments/assets/c738d157-c53c-45a0-99d3-1dc1b4d92390)_



Necessary plumbing to build a truly independent data layer and UX layer. This will allow us to re-tool the UX and data layers separately from one another, allowing us to build more robust interfaces in the future (modern UX on the web, modes such as dark/light/color-blind/etc..., mobile views, even CLI or TUI if we feel adventurous!).

Breakdown of the high-impact changes in this feature branch.

### What

Separated the comparison domain from the web presentation layer so game comparison logic can be reused outside the current Jinja/HTMX flow. This introduces a typed comparison/query contract, a small web adapter layer, and a new `/api/games` JSON endpoint.

### How

`games/service.py` now owns a UX-neutral comparison model and refresh-planning logic, while `games/web.py` translates request/preferences state into that model and shapes results back into the existing page contract. `games/routes.py` was updated to use that split without changing the current authenticated template system, which keeps this PR focused on data/service boundaries and creates the seam the next PR uses to swap in templated authenticated UX.

