### PR TITLE
[3 / 3] Add the first non-OG "modern" template

### DIFF
--- a/infrastructure/cdk/README.md
+++ b/infrastructure/cdk/README.md
@@ -57,12 +57,17 @@ npx cdk deploy
 
 Domain and sender values are **not** stored in this public repo. They come from
 a private config file, by default `../gamatrix-configs/cdk-config.yaml`
-(override the directory with `GAMATRIX_CONFIG_DIR`):
+(override the directory with `GAMATRIX_CONFIG_DIR`).
+
+Set `ux_template: default` or `ux_template: modern` in that file to select the
+authenticated UX for the deployment. Users can change display mode, but cannot
+change the deployment-selected template:
 
 ```yaml
 hosted_zone: example.com          # existing Route 53 hosted zone
 site_domain: gamatrix.example.com # public hostname for the app
 email_from: noreply@example.com   # SES sender for password-reset email
+ux_template: modern               # default or modern authenticated UX
 
 # Optional: extra hostnames that should also resolve to the same app.
 # alias_hosted_zone must be a Route 53-managed zone; alias_domains must be

--- a/infrastructure/cdk/config.py
+++ b/infrastructure/cdk/config.py
@@ -18,6 +18,7 @@ from pathlib import Path
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_CONFIG_DIR = PROJECT_ROOT.parent / "gamatrix-configs"
+UX_TEMPLATES = ("default", "modern")
 
 
 @dataclass
@@ -30,6 +31,7 @@ class DeployConfig:
     # is extended with SANs for all alias_domains so there are no cert warnings.
     alias_hosted_zone: str | None = None
     alias_domains: list[str] = field(default_factory=list)
+    ux_template: str = "default"
 
     @property
     def has_custom_domain(self) -> bool:
@@ -56,6 +58,9 @@ def load_deploy_config() -> DeployConfig:
     alias_hosted_zone = data.get("alias_hosted_zone")
     if alias_domains and not alias_hosted_zone:
         raise ValueError("alias_hosted_zone is required when alias_domains is set")
+    ux_template = data.get("ux_template", "default")
+    if ux_template not in UX_TEMPLATES:
+        raise ValueError(f"ux_template must be one of: {', '.join(UX_TEMPLATES)}")
 
     return DeployConfig(
         hosted_zone=data.get("hosted_zone"),
@@ -63,4 +68,5 @@ def load_deploy_config() -> DeployConfig:
         email_from=data.get("email_from"),
         alias_hosted_zone=alias_hosted_zone,
         alias_domains=alias_domains,
+        ux_template=ux_template,
     )

--- a/infrastructure/cdk/config.py
+++ b/infrastructure/cdk/config.py
@@ -13,12 +13,19 @@ Gateway URL -- so anyone can clone and deploy this repo without owning a domain.
 from __future__ import annotations
 
 import os
+import sys
 from dataclasses import dataclass, field
+
 from pathlib import Path
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_CONFIG_DIR = PROJECT_ROOT.parent / "gamatrix-configs"
-UX_TEMPLATES = ("default", "modern")
+# We need to share some information/functionality with the runtime surrounding templates.
+SRC_DIR = PROJECT_ROOT / "src"
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+from gamatrix.ux_templates import DEFAULT_UX_TEMPLATE, canonicalize_ux_template_name
 
 
 @dataclass
@@ -31,7 +38,7 @@ class DeployConfig:
     # is extended with SANs for all alias_domains so there are no cert warnings.
     alias_hosted_zone: str | None = None
     alias_domains: list[str] = field(default_factory=list)
-    ux_template: str = "default"
+    ux_template: str = DEFAULT_UX_TEMPLATE
 
     @property
     def has_custom_domain(self) -> bool:
@@ -41,12 +48,11 @@ class DeployConfig:
 def load_deploy_config() -> DeployConfig:
     config_dir = Path(os.environ.get("GAMATRIX_CONFIG_DIR", DEFAULT_CONFIG_DIR))
     path = config_dir / "cdk-config.yaml"
-    if not path.exists():
-        return DeployConfig()
+    data = {}
+    if path.exists():
+        import yaml
 
-    import yaml
-
-    data = yaml.safe_load(path.read_text()) or {}
+        data = yaml.safe_load(path.read_text()) or {}
 
     alias_domains = data.get("alias_domains") or []
     # YAML happily parses `alias_domains: games.other.com` as a scalar string.
@@ -58,9 +64,9 @@ def load_deploy_config() -> DeployConfig:
     alias_hosted_zone = data.get("alias_hosted_zone")
     if alias_domains and not alias_hosted_zone:
         raise ValueError("alias_hosted_zone is required when alias_domains is set")
-    ux_template = data.get("ux_template", "default")
-    if ux_template not in UX_TEMPLATES:
-        raise ValueError(f"ux_template must be one of: {', '.join(UX_TEMPLATES)}")
+    ux_template = canonicalize_ux_template_name(
+        data.get("ux_template", DEFAULT_UX_TEMPLATE)
+    )
 
     return DeployConfig(
         hosted_zone=data.get("hosted_zone"),

--- a/infrastructure/cdk/gamatrix_stack.py
+++ b/infrastructure/cdk/gamatrix_stack.py
@@ -150,6 +150,7 @@ class GamatrixStack(Stack):
             "JWT_SECRET_NAME": jwt_secret.secret_name,
             "EMAIL_FROM": cfg.email_from or DEFAULT_EMAIL_FROM,
             "IGDB_STALE_DAYS": "30",
+            "UX_TEMPLATE": cfg.ux_template,
             "WEBAUTHN_RP_ID": cfg.site_domain or "",
             "WEBAUTHN_ORIGINS": (
                 f'["https://{cfg.site_domain}"]' if cfg.site_domain else "[]"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ fallback_version = "0.0.0"
 where = ["src"]
 
 [tool.setuptools.package-data]
-"gamatrix.templates" = ["*.jinja", "**/*.jinja"]
+"gamatrix.templates" = ["*.jinja", "**/*.jinja", "**/valid_template"]
 "gamatrix.static" = ["*.png", "*.jpg", "*.css", "*.js", "**/*.png", "**/*.jpg", "**/*.css", "**/*.js"]
 "gamatrix.static.profile_img" = ["*.png", "*.jpg"]
 

--- a/src/gamatrix/app.py
+++ b/src/gamatrix/app.py
@@ -17,8 +17,10 @@ from fastapi.staticfiles import StaticFiles
 from gamatrix import __version__
 from gamatrix.auth.dependencies import RedirectToLogin
 from gamatrix.auth.routes import router as auth_router
+from gamatrix.config import get_settings
 from gamatrix.games.routes import router as games_router
 from gamatrix.preferences import router as preferences_router
+from gamatrix.templating import configure_authenticated_templates
 from gamatrix.upload import router as upload_router
 
 logging.basicConfig(
@@ -26,6 +28,9 @@ logging.basicConfig(
     level=logging.INFO,
     datefmt="%Y-%m-%d %H:%M:%S",
 )
+
+settings = get_settings()
+configure_authenticated_templates(settings.ux_template)
 
 app = FastAPI(title="gamatrix", version=__version__)
 

--- a/src/gamatrix/config.py
+++ b/src/gamatrix/config.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 from functools import lru_cache
+from typing import Literal
 
 from pydantic import model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -70,6 +71,7 @@ class Settings(BaseSettings):
     # --- Behavior ---
     app_base_url: str = "http://localhost:8088"
     igdb_stale_days: int = 30
+    ux_template: Literal["default", "modern"] = "default"
 
     # SSM parameter names for the title filter lists (AWS only). Locally these
     # are seeded into DynamoDB config and read from there.

--- a/src/gamatrix/config.py
+++ b/src/gamatrix/config.py
@@ -10,10 +10,11 @@ from __future__ import annotations
 
 import json
 from functools import lru_cache
-from typing import Literal
 
 from pydantic import model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+from gamatrix.ux_templates import DEFAULT_UX_TEMPLATE, canonicalize_ux_template_name
 
 DEFAULT_JWT_SECRET = "change-me-in-production"
 
@@ -71,7 +72,7 @@ class Settings(BaseSettings):
     # --- Behavior ---
     app_base_url: str = "http://localhost:8088"
     igdb_stale_days: int = 30
-    ux_template: Literal["default", "modern"] = "default"
+    ux_template: str = DEFAULT_UX_TEMPLATE
 
     # SSM parameter names for the title filter lists (AWS only). Locally these
     # are seeded into DynamoDB config and read from there.
@@ -124,9 +125,8 @@ class Settings(BaseSettings):
 
     @model_validator(mode="after")
     def _require_jwt_secret(self) -> "Settings":
-        """Fail loudly rather than silently signing sessions with the public
-        default secret in production. Either set JWT_SECRET directly or point
-        JWT_SECRET_NAME at a Secrets Manager secret."""
+        """Validate settings that must match shipped assets or production rules."""
+        self.ux_template = canonicalize_ux_template_name(self.ux_template)
         if (
             not self.local_dev
             and not self.jwt_secret_name

--- a/src/gamatrix/games/routes.py
+++ b/src/gamatrix/games/routes.py
@@ -80,6 +80,7 @@ def games_table(
         request,
         "games_table.html.jinja",
         {
+            "user": user,
             "users": users,
             "games": web.present_games(result, opts),
             "caption": caption,
@@ -118,7 +119,7 @@ def job_status(
     return authenticated_fragment(
         request,
         "job_status.html.jinja",
-        {"job": job, "job_id": job_id, "done": done},
+        {"user": user, "job": job, "job_id": job_id, "done": done},
     )
 
 
@@ -144,6 +145,7 @@ def refresh_missing(
         request,
         "job_status.html.jinja",
         {
+            "user": admin,
             "job": repo.get_job(job_id) if job_id else None,
             "job_id": job_id,
             "done": job_id is None,
@@ -169,6 +171,7 @@ def refresh_all(
         request,
         "job_status.html.jinja",
         {
+            "user": admin,
             "job": repo.get_job(job_id) if job_id else None,
             "job_id": job_id,
             "done": job_id is None,

--- a/src/gamatrix/games/routes.py
+++ b/src/gamatrix/games/routes.py
@@ -81,7 +81,6 @@ def games_table(
         request,
         "games_table.html.jinja",
         {
-            "user": user,
             "users": users,
             "games": web.present_games(result, opts),
             "caption": caption,
@@ -120,7 +119,7 @@ def job_status(
     return authenticated_fragment(
         request,
         "job_status.html.jinja",
-        {"user": user, "job": job, "job_id": job_id, "done": done},
+        {"job": job, "job_id": job_id, "done": done},
     )
 
 
@@ -146,7 +145,6 @@ def refresh_missing(
         request,
         "job_status.html.jinja",
         {
-            "user": admin,
             "job": repo.get_job(job_id) if job_id else None,
             "job_id": job_id,
             "done": job_id is None,
@@ -172,7 +170,6 @@ def refresh_all(
         request,
         "job_status.html.jinja",
         {
-            "user": admin,
             "job": repo.get_job(job_id) if job_id else None,
             "job_id": job_id,
             "done": job_id is None,

--- a/src/gamatrix/games/routes.py
+++ b/src/gamatrix/games/routes.py
@@ -28,17 +28,6 @@ from gamatrix.templating import authenticated_fragment, authenticated_template
 router = APIRouter(tags=["games"])
 
 
-def _maybe_enrich(repo: Repository, opts: WebCompareOptions) -> str | None:
-    """Find stale/pending games among the selected libraries and enqueue a job.
-
-    If a job is already pending or running, return its id rather than
-    creating a duplicate — each /games page load would otherwise queue a
-    new batch of the same games, exhausting Lambda concurrency.
-    """
-    advice = service.ensure_enrichment_job(repo, get_queue(), opts.to_query())
-    return advice.job_id
-
-
 @router.get("/games", response_class=HTMLResponse)
 def games_page(
     request: Request,
@@ -46,7 +35,9 @@ def games_page(
     repo: Repository = Depends(get_repo),
 ):
     opts = web.parse_options(request, user, repo)
-    job_id = _maybe_enrich(repo, opts)
+    # Reuse an active enrichment job rather than queueing duplicate work on
+    # every page load for the same stale selection.
+    job_id = service.ensure_enrichment_job(repo, get_queue(), opts.to_query())
     users = {str(u["user_id"]): u for u in repo.scan_users() if u.get("user_id")}
     result = service.compare(repo, opts.to_query())
     caption = web.build_caption(users, opts, result)

--- a/src/gamatrix/games/routes.py
+++ b/src/gamatrix/games/routes.py
@@ -27,7 +27,6 @@ from gamatrix.templating import authenticated_fragment, authenticated_template
 
 router = APIRouter(tags=["games"])
 
-
 def _maybe_enrich(repo: Repository, opts: WebCompareOptions) -> str | None:
     """Find stale/pending games among the selected libraries and enqueue a job.
 

--- a/src/gamatrix/games/routes.py
+++ b/src/gamatrix/games/routes.py
@@ -27,6 +27,7 @@ from gamatrix.templating import authenticated_fragment, authenticated_template
 
 router = APIRouter(tags=["games"])
 
+
 def _maybe_enrich(repo: Repository, opts: WebCompareOptions) -> str | None:
     """Find stale/pending games among the selected libraries and enqueue a job.
 

--- a/src/gamatrix/games/service.py
+++ b/src/gamatrix/games/service.py
@@ -100,7 +100,6 @@ class RefreshAdvice:
 
 def compare(repo: ComparisonRepository, query: ComparisonQuery) -> ComparisonDataset:
     users = {str(u["user_id"]): u for u in repo.scan_users() if u.get("user_id")}
-
     selected = [str(u) for u in query.selected_user_ids if str(u) in users]
 
     # For exclusive mode we need to know who else owns each game.

--- a/src/gamatrix/games/service.py
+++ b/src/gamatrix/games/service.py
@@ -90,14 +90,6 @@ class ComparisonDataset:
     total: int
 
 
-@dataclass
-class RefreshAdvice:
-    job_id: str | None
-    stale_release_keys: list[str] = field(default_factory=list)
-    reused_active_job: bool = False
-    created_job: bool = False
-
-
 def compare(repo: ComparisonRepository, query: ComparisonQuery) -> ComparisonDataset:
     users = {str(u["user_id"]): u for u in repo.scan_users() if u.get("user_id")}
     selected = [str(u) for u in query.selected_user_ids if str(u) in users]
@@ -252,25 +244,17 @@ def ensure_enrichment_job(
     queue: EnrichmentQueue,
     query: ComparisonQuery,
     settings: Settings | None = None,
-) -> RefreshAdvice:
+) -> str | None:
     """Ensure the selected libraries have an active refresh job if needed."""
     active = repo.get_active_job()
     if active:
-        return RefreshAdvice(
-            job_id=active["job_id"],
-            reused_active_job=True,
-        )
+        return active["job_id"]
 
     stale = stale_release_keys(repo, query, settings=settings)
     if not stale:
-        return RefreshAdvice(job_id=None, stale_release_keys=[])
+        return None
 
-    job_id = create_enrichment_job(repo, queue, stale)
-    return RefreshAdvice(
-        job_id=job_id,
-        stale_release_keys=stale,
-        created_job=job_id is not None,
-    )
+    return create_enrichment_job(repo, queue, stale)
 
 
 def stale_release_keys(

--- a/src/gamatrix/games/service.py
+++ b/src/gamatrix/games/service.py
@@ -100,6 +100,7 @@ class RefreshAdvice:
 
 def compare(repo: ComparisonRepository, query: ComparisonQuery) -> ComparisonDataset:
     users = {str(u["user_id"]): u for u in repo.scan_users() if u.get("user_id")}
+
     selected = [str(u) for u in query.selected_user_ids if str(u) in users]
 
     # For exclusive mode we need to know who else owns each game.

--- a/src/gamatrix/static/templates/modern/style.css
+++ b/src/gamatrix/static/templates/modern/style.css
@@ -1,0 +1,224 @@
+/* Modern authenticated UX: lightweight, responsive, and asset-free. */
+:root,
+body[data-mode="light"] {
+  --page: #edf3f5;
+  --surface: #ffffff;
+  --surface-alt: #f4f8f9;
+  --text: #243238;
+  --muted: #60747d;
+  --border: #c7d5da;
+  --accent: #087f8c;
+  --accent-text: #ffffff;
+  --row-a: #ffffff;
+  --row-b: #edf7f7;
+  --owned: #ccebd8;
+  --unowned: #f7d3cf;
+  --warning: #855f00;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --page: #111b20;
+    --surface: #19272d;
+    --surface-alt: #22333a;
+    --text: #e4edf0;
+    --muted: #aabcc3;
+    --border: #49616a;
+    --accent: #6ed7df;
+    --accent-text: #102329;
+    --row-a: #19272d;
+    --row-b: #203239;
+    --owned: #28573e;
+    --unowned: #673c3c;
+    --warning: #ffd166;
+  }
+}
+
+body[data-mode="dark"] {
+  --page: #111b20;
+  --surface: #19272d;
+  --surface-alt: #22333a;
+  --text: #e4edf0;
+  --muted: #aabcc3;
+  --border: #49616a;
+  --accent: #6ed7df;
+  --accent-text: #102329;
+  --row-a: #19272d;
+  --row-b: #203239;
+  --owned: #28573e;
+  --unowned: #673c3c;
+  --warning: #ffd166;
+}
+
+body[data-mode="high-contrast"] {
+  --page: #000000;
+  --surface: #000000;
+  --surface-alt: #111111;
+  --text: #ffffff;
+  --muted: #ffffff;
+  --border: #ffffff;
+  --accent: #ffff00;
+  --accent-text: #000000;
+  --row-a: #000000;
+  --row-b: #191919;
+  --owned: #004d00;
+  --unowned: #620000;
+  --warning: #ffff00;
+}
+
+body[data-mode="color-blind"] {
+  --page: #f2f2f2;
+  --surface: #ffffff;
+  --surface-alt: #f1f5fb;
+  --text: #172033;
+  --muted: #4f5b70;
+  --border: #aeb9ca;
+  --accent: #005ab5;
+  --accent-text: #ffffff;
+  --row-a: #ffffff;
+  --row-b: #e9f2ff;
+  --owned: #ffdf80;
+  --unowned: #b8d8ff;
+  --warning: #9b4f00;
+}
+
+* { box-sizing: border-box; }
+body {
+  max-width: 1500px;
+  margin: 0 auto;
+  padding: 0 1rem 2rem;
+  background: var(--page);
+  color: var(--text);
+  font-family: Arial, Helvetica, sans-serif;
+  line-height: 1.45;
+}
+a { color: var(--accent); }
+a:focus-visible, button:focus-visible, input:focus-visible {
+  outline: 3px solid var(--accent);
+  outline-offset: 2px;
+}
+h1, h2, h3 { line-height: 1.15; }
+.topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin: 0 -1rem 1.25rem;
+  padding: 1rem 1.25rem;
+  background: var(--surface);
+  border-bottom: 4px solid var(--accent);
+}
+.topbar h2 { margin: 0; letter-spacing: .03em; }
+.topbar .right { display: flex; flex-wrap: wrap; align-items: center; gap: .9rem; }
+.filters, .card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, .08);
+  padding: 1rem;
+  margin-bottom: 1rem;
+}
+.filters {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
+  gap: 1.25rem;
+}
+.filters fieldset { min-width: 0; margin: 0; padding: 0; border: 0; }
+.filters legend { margin-bottom: .45rem; color: var(--accent); font-weight: bold; }
+.filter-group { display: flex; flex-direction: column; gap: .3rem; }
+.filters label { display: flex; align-items: center; gap: .35rem; }
+.platform-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: .25rem; }
+button, .btn {
+  border: 1px solid var(--accent);
+  border-radius: 2px;
+  padding: .45rem .8rem;
+  background: var(--accent);
+  color: var(--accent-text);
+  font: inherit;
+  font-weight: bold;
+  cursor: pointer;
+}
+button.secondary { background: var(--surface-alt); color: var(--text); }
+button:hover, .btn:hover { filter: brightness(.92); }
+.card { max-width: 420px; margin: 2rem auto; }
+.card.wide { max-width: 780px; }
+.card input[type=email], .card input[type=password], .card input[type=text] {
+  width: 100%;
+  margin: .35rem 0 .8rem;
+  padding: .55rem;
+  border: 1px solid var(--border);
+  background: var(--surface-alt);
+  color: var(--text);
+}
+table.results {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  background: var(--surface);
+  border-left: 1px solid var(--border);
+}
+table.results caption { padding: .65rem 0; color: var(--text); text-align: left; font-weight: bold; }
+table.results th, table.results td {
+  padding: .5rem .65rem;
+  border-right: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+}
+table.results thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  border-top: 1px solid var(--border);
+  background: var(--accent);
+  color: var(--accent-text);
+  cursor: pointer;
+  text-align: left;
+}
+table.results tbody tr:nth-child(odd) { background: var(--row-a); }
+table.results tbody tr:nth-child(even) { background: var(--row-b); }
+table.results td.owned { background: var(--owned); }
+table.results td.unowned { background: var(--unowned); }
+table.results tr.subthreshold td { color: var(--warning); }
+.platform-icons { float: right; white-space: nowrap; }
+.platform-icons img { vertical-align: middle; }
+.sort-arrow { font-size: .8em; }
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+.job-progress { padding: .75rem; margin-bottom: 1rem; border: 1px solid var(--accent); background: var(--surface); }
+.bar { height: .65rem; overflow: hidden; background: var(--surface-alt); border: 1px solid var(--border); }
+.bar > span { display: block; height: 100%; background: var(--accent); }
+.passkey-list, .token-list { list-style: none; padding: 0; }
+.passkey-list li, .token-list li {
+  display: flex; align-items: center; gap: 1rem; padding: .6rem 0;
+  border-bottom: 1px solid var(--border);
+}
+.passkey-list li .muted, .token-list li .muted { flex: 1; }
+.token-box {
+  white-space: pre-wrap;
+  word-break: break-all;
+  padding: .75rem;
+  border: 1px solid var(--border);
+  background: var(--surface-alt);
+  font-family: Consolas, "Courier New", monospace;
+  font-size: .85rem;
+}
+.help-icon { display: inline-flex; align-items: center; justify-content: center; width: 1rem; height: 1rem; border: 1px solid var(--border); border-radius: 50%; }
+.muted { color: var(--muted); font-size: .9rem; }
+.error { color: #c62828; }
+footer { padding-top: 1rem; }
+
+@media (max-width: 720px) {
+  body { padding: 0 .5rem 1rem; }
+  .topbar { align-items: flex-start; flex-direction: column; margin: 0 -.5rem 1rem; }
+  .filters { grid-template-columns: 1fr; }
+  #games-container { overflow-x: auto; }
+  table.results { min-width: 680px; }
+}

--- a/src/gamatrix/templates/default/games.html.jinja
+++ b/src/gamatrix/templates/default/games.html.jinja
@@ -27,7 +27,14 @@
     <fieldset class="filter-group">
         <legend>Users</legend>
         {% for uid, u in users.items() %}
-        <label title="DB updated: {{ u.get('db_updated_at', 'never') }}">
+        {% set db_updated_at = u.get('db_updated_at') %}
+        <label class="user-db-updated"
+               {% if db_updated_at and db_updated_at != 'never' %}
+               data-db-updated="{{ db_updated_at }}"
+               title="DB updated: loading local time..."
+               {% else %}
+               title="DB updated: never"
+               {% endif %}>
             <input type="checkbox" name="user" value="{{ uid }}"
                    {% if uid in opts.selected_user_ids %}checked{% endif %}>
             {% set pu = pic_url(u) %}
@@ -95,4 +102,23 @@
 <div id="games-container">
     {% include "games_table.html.jinja" %}
 </div>
+<script>
+(function () {
+    function localizeDbUpdatedTooltips() {
+        for (const el of document.querySelectorAll(".user-db-updated[data-db-updated]")) {
+            const iso = el.dataset.dbUpdated;
+            if (!iso) { continue; }
+            const when = new Date(iso);
+            if (isNaN(when)) { continue; }
+            el.title = `DB updated: ${when.toLocaleString()}`;
+        }
+    }
+
+    if (document.readyState === "loading") {
+        document.addEventListener("DOMContentLoaded", localizeDbUpdatedTooltips, { once: true });
+    } else {
+        localizeDbUpdatedTooltips();
+    }
+})();
+</script>
 {% endblock %}

--- a/src/gamatrix/templates/modern/base.html.jinja
+++ b/src/gamatrix/templates/modern/base.html.jinja
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{% block title %}gamatrix{% endblock %}</title>
+    {# Version query busts the browser cache on each deploy so CSS changes
+       (e.g. the sticky results header) aren't masked by a stale stylesheet. #}
+    <link rel="stylesheet" href="/static/templates/modern/style.css?v={{ version }}">
+    <script src="https://unpkg.com/htmx.org@2.0.4"></script>
+</head>
+<body{% if display_mode %} data-mode="{{ display_mode }}"{% endif %}>
+{% block body %}{% endblock %}
+<footer class="muted" style="margin-top:2rem;">gamatrix v{{ version }}</footer>
+</body>
+</html>

--- a/src/gamatrix/templates/modern/games.html.jinja
+++ b/src/gamatrix/templates/modern/games.html.jinja
@@ -1,0 +1,98 @@
+{% extends "base.html.jinja" %}
+{% block title %}gamatrix{% endblock %}
+{% block body %}
+<div class="topbar">
+    <h2>gamatrix</h2>
+    <div class="right">
+        <span class="muted">{{ user.email }}</span>
+        <a href="/upload">Upload DB</a>
+        <a href="/preferences">Preferences</a>
+        <form method="post" action="/auth/logout" style="display:inline;">
+            <button class="secondary" type="submit">Sign out</button>
+        </form>
+    </div>
+</div>
+
+<form id="filters"
+      hx-get="/games/table"
+      hx-target="#games-container"
+      hx-trigger="change"
+      hx-include="#filters"
+      class="filters">
+
+    {# Marks requests as coming from the filter form so the server treats an
+       unchecked checkbox as "off" rather than falling back to a saved pref. #}
+    <input type="hidden" name="filters_active" value="1">
+
+    <fieldset class="filter-group">
+        <legend>Users</legend>
+        {% for uid, u in users.items() %}
+        <label title="DB updated: {{ u.get('db_updated_at', 'never') }}">
+            <input type="checkbox" name="user" value="{{ uid }}"
+                   {% if uid in opts.selected_user_ids %}checked{% endif %}>
+            {% set pu = pic_url(u) %}
+            {% if pu %}<img src="{{ pu }}" width="18" height="18">{% endif %}
+            {{ u.username }}
+        </label>
+        {% endfor %}
+    </fieldset>
+
+    <fieldset class="filter-group">
+        <legend>View</legend>
+        <label><input type="radio" name="view" value="list"
+            {% if not is_grid %}checked{% endif %}> Game list</label>
+        <label><input type="radio" name="view" value="grid"
+            {% if is_grid %}checked{% endif %}> Game grid</label>
+    </fieldset>
+
+    <fieldset class="filter-group">
+        <legend>Options</legend>
+        <label><input type="checkbox" name="single_player" value="true"
+            {% if opts.include_single_player %}checked{% endif %}> Include single-player</label>
+        <label><input type="checkbox" name="installed_only" value="true"
+            {% if opts.installed_only %}checked{% endif %}> Installed only</label>
+        <label><input type="checkbox" name="exclusive" value="true"
+            {% if opts.exclusive %}checked{% endif %}> Exclusively owned</label>
+        <label><input type="checkbox" name="randomize" value="true"
+            {% if opts.randomize %}checked{% endif %}> Pick a random game</label>
+        <label><input type="checkbox" name="show_keys" value="true"
+            {% if opts.show_keys %}checked{% endif %}> Show product keys</label>
+    </fieldset>
+
+    <fieldset class="filter-group">
+        <legend>Exclude platforms</legend>
+        <div class="platform-grid">
+            {% for p in platforms %}
+            <label><input type="checkbox" name="exclude" value="{{ p }}"
+                {% if p in opts.exclude_platforms %}checked{% endif %}>
+                <img src="/static/{{ p }}.png" width="18" height="18"> {{ p|capitalize }}</label>
+            {% endfor %}
+        </div>
+    </fieldset>
+
+    <fieldset class="filter-group">
+        <legend>&nbsp;</legend>
+        <button type="button"
+                hx-post="/preferences"
+                hx-include="#filters"
+                hx-swap="none">Save as defaults</button>
+        {% if user.is_admin %}
+        <button type="button" class="secondary"
+                hx-post="/games/refresh-igdb"
+                hx-target="#job-status">Refresh missing IGDB</button>
+        <button type="button" class="secondary"
+                hx-post="/games/refresh-igdb-all"
+                hx-target="#job-status"
+                hx-confirm="Re-fetch IGDB data for ALL games?">Refresh all IGDB</button>
+        {% endif %}
+    </fieldset>
+</form>
+
+<div id="job-status">
+    {% if job_id %}{% include "job_status.html.jinja" %}{% endif %}
+</div>
+
+<div id="games-container">
+    {% include "games_table.html.jinja" %}
+</div>
+{% endblock %}

--- a/src/gamatrix/templates/modern/games.html.jinja
+++ b/src/gamatrix/templates/modern/games.html.jinja
@@ -27,7 +27,14 @@
     <fieldset class="filter-group">
         <legend>Users</legend>
         {% for uid, u in users.items() %}
-        <label title="DB updated: {{ u.get('db_updated_at', 'never') }}">
+        {% set db_updated_at = u.get('db_updated_at') %}
+        <label class="user-db-updated"
+               {% if db_updated_at and db_updated_at != 'never' %}
+               data-db-updated="{{ db_updated_at }}"
+               title="DB updated: loading local time..."
+               {% else %}
+               title="DB updated: never"
+               {% endif %}>
             <input type="checkbox" name="user" value="{{ uid }}"
                    {% if uid in opts.selected_user_ids %}checked{% endif %}>
             {% set pu = pic_url(u) %}
@@ -95,4 +102,23 @@
 <div id="games-container">
     {% include "games_table.html.jinja" %}
 </div>
+<script>
+(function () {
+    function localizeDbUpdatedTooltips() {
+        for (const el of document.querySelectorAll(".user-db-updated[data-db-updated]")) {
+            const iso = el.dataset.dbUpdated;
+            if (!iso) { continue; }
+            const when = new Date(iso);
+            if (isNaN(when)) { continue; }
+            el.title = `DB updated: ${when.toLocaleString()}`;
+        }
+    }
+
+    if (document.readyState === "loading") {
+        document.addEventListener("DOMContentLoaded", localizeDbUpdatedTooltips, { once: true });
+    } else {
+        localizeDbUpdatedTooltips();
+    }
+})();
+</script>
 {% endblock %}

--- a/src/gamatrix/templates/modern/games_table.html.jinja
+++ b/src/gamatrix/templates/modern/games_table.html.jinja
@@ -1,0 +1,95 @@
+{# Renders the results table. Swapped in by HTMX on filter/sort changes. #}
+{% macro sort_header(label, col) %}
+    {% set next_dir = 'desc' if (opts.sort == col and opts.direction == 'asc') else 'asc' %}
+    <th hx-get="/games/table?sort={{ col }}&dir={{ next_dir }}"
+        hx-include="#filters"
+        hx-target="#games-container">
+        {{ label }}
+        {% if opts.sort == col %}
+        <span class="sort-arrow">{{ '▲' if opts.direction == 'asc' else '▼' }}</span>
+        {% endif %}
+    </th>
+{% endmacro %}
+
+{% set selected = opts.selected_user_ids %}
+<table class="results">
+    <caption>{{ caption }}</caption>
+    <thead>
+        <tr>
+            {{ sort_header('Title', 'title') }}
+            {% if is_grid %}
+                {% for uid in selected %}
+                {% if uid in users %}
+                <th title="{{ users[uid].username }}">
+                    {% set pu = pic_url(users[uid]) %}
+                    {% if pu %}
+                    <img src="{{ pu }}" width="20" height="20">
+                    {% else %}{{ users[uid].username }}{% endif %}
+                </th>
+                {% endif %}
+                {% endfor %}
+            {% endif %}
+            {{ sort_header('Players', 'players') }}
+            {{ sort_header('Rating', 'rating') }}
+            {% if not is_grid %}
+                {{ sort_header('Installed', 'installed') }}
+            {% endif %}
+            <th>Comment</th>
+            {% if opts.show_keys %}<th>Release Key</th>{% endif %}
+        </tr>
+    </thead>
+    <tbody>
+    {% for game in games %}
+        {% set mp = game.max_players|default(0)|int %}
+        <tr class="{{ 'subthreshold' if (mp > 0 and mp < selected|length) else '' }}">
+            <td>
+                {% if game.url %}<a href="{{ game.url }}">{{ game.title }}</a>
+                {% else %}{{ game.title }}{% endif %}
+                <span class="platform-icons">
+                    {% for p in game.platforms %}
+                    {% if p in platforms %}
+                    <img src="/static/{{ p }}.png" width="20" height="20" title="{{ p }}">
+                    {% else %}
+                    <img src="/static/profile_img/question_block.jpg" width="20" height="20" title="{{ p }}">
+                    {% endif %}
+                    {% endfor %}
+                </span>
+            </td>
+            {% if is_grid %}
+                {% for uid in selected %}
+                {% if uid in users %}
+                <td class="{{ 'owned' if uid in game.owners else 'unowned' }}" style="text-align:center;">
+                    <span class="visually-hidden">{{ 'Owned' if uid in game.owners else 'Not owned' }}</span>
+                    {% if uid in game.installed %}
+                        {% set pu = pic_url(users[uid]) %}
+                        {% if pu %}
+                        <img src="{{ pu }}" width="18" height="18" title="installed">
+                        {% else %}✓{% endif %}
+                    {% endif %}
+                </td>
+                {% endif %}
+                {% endfor %}
+            {% endif %}
+            <td>{% if mp > 0 %}{{ mp }}{% endif %}</td>
+            <td>{% if game.rating %}{{ game.rating }}{% endif %}</td>
+            {% if not is_grid %}
+            <td style="text-align:center;">
+                {% if selected|length == game.installed|length and game.installed %}
+                    <b>✓</b>
+                {% else %}
+                    {% for uid in game.installed if uid in users %}
+                    {% set pu = pic_url(users[uid]) %}
+                    {% if pu %}
+                    <img src="{{ pu }}" width="18" height="18" title="{{ users[uid].username }}">
+                    {% else %}{{ users[uid].username }}{% endif %}
+                    {% endfor %}
+                {% endif %}
+            </td>
+            {% endif %}
+            <td>{{ game.comment }}</td>
+            {% if opts.show_keys %}<td>{{ game.release_key }}</td>{% endif %}
+        </tr>
+    {% endfor %}
+    </tbody>
+</table>
+{% if not games %}<p class="muted">No games match the current filters.</p>{% endif %}

--- a/src/gamatrix/templates/modern/job_status.html.jinja
+++ b/src/gamatrix/templates/modern/job_status.html.jinja
@@ -1,0 +1,23 @@
+{# Enrichment progress. Polls itself every 3s; when done, reloads the table. #}
+{% if done %}
+    {# Job finished: pull in fresh data, then this element clears itself out. #}
+    <div hx-get="/games/table"
+         hx-include="#filters"
+         hx-target="#games-container"
+         hx-trigger="load"
+         hx-swap="innerHTML">
+    </div>
+{% else %}
+    {% set total = job.total|default(1) %}
+    {# Clamp: progress should never exceed total, but guard the display in case
+       a job's count was inflated by a retry before it settled (see #131). #}
+    {% set done_count = [job.completed_count|default(0), total]|min %}
+    {% set pct = (done_count * 100 // total) if total else 0 %}
+    <div class="job-progress"
+         hx-get="/api/jobs/{{ job_id }}"
+         hx-trigger="every 3s"
+         hx-swap="outerHTML">
+        Updating game data from IGDB… {{ done_count }} / {{ total }}
+        <div class="bar"><span style="width: {{ pct }}%;"></span></div>
+    </div>
+{% endif %}

--- a/src/gamatrix/templates/modern/passkeys.html.jinja
+++ b/src/gamatrix/templates/modern/passkeys.html.jinja
@@ -1,0 +1,50 @@
+{% extends "base.html.jinja" %}
+{% block title %}gamatrix — passkeys{% endblock %}
+{% block body %}
+<div class="topbar">
+    <h2>Passkeys</h2>
+    <div class="right"><a href="/preferences">Back to preferences</a></div>
+</div>
+
+<div class="card wide">
+    <h3>Add a passkey</h3>
+    <p class="muted">Passkeys can use this device, a synced provider, a phone, or a compatible security key.</p>
+    <form id="passkey-register">
+        <label for="friendly_name">Passkey name</label>
+        <input type="text" id="friendly_name" name="friendly_name" maxlength="100"
+               value="Gamatrix passkey for {{ user.username }}" required>
+        <label for="current_password">Current password
+            <span class="help-icon" title="Required to verify your identity before adding a passkey"
+                  aria-label="Required to verify your identity before adding a passkey" tabindex="0">?</span>
+        </label>
+        <input type="password" id="current_password" name="password" required autocomplete="current-password">
+        <button type="submit">Add passkey</button>
+    </form>
+    <p id="passkey-waiting" class="muted" hidden>Waiting for passkey creation to complete...</p>
+    <p id="passkey-error" class="error" hidden></p>
+</div>
+
+<div class="card wide">
+    <h3>Registered passkeys</h3>
+    {% if passkeys %}
+    <ul class="passkey-list">
+        {% for passkey in passkeys %}
+        <li>
+            <strong>{{ passkey.friendly_name }}</strong>
+            <span class="muted">
+                {% if passkey.backup_eligible %}sync-capable{% else %}device-bound{% endif %}
+                {% if passkey.backed_up %}, backed up{% endif %}
+                {% if passkey.created_at %} - added {{ passkey.created_at[:10] }}{% endif %}
+            </span>
+            <button type="button" class="secondary delete-passkey"
+                    data-credential-id="{{ passkey.credential_id }}">Delete</button>
+        </li>
+        {% endfor %}
+    </ul>
+    {% else %}
+    <p class="muted">No passkeys registered.</p>
+    {% endif %}
+</div>
+<script src="/static/passkeys.js"></script>
+<script>window.gamatrixPasskeys.enableManagement();</script>
+{% endblock %}

--- a/src/gamatrix/templates/modern/passkeys_list.html.jinja
+++ b/src/gamatrix/templates/modern/passkeys_list.html.jinja
@@ -1,0 +1,28 @@
+{% extends "base.html.jinja" %}
+{% block title %}gamatrix — passkeys{% endblock %}
+{% block body %}
+<div class="topbar">
+    <h2>Passkeys</h2>
+    <div class="right"><a href="/preferences">Back to preferences</a></div>
+</div>
+
+<div class="card wide">
+    <h3>Registered passkeys</h3>
+    {% if passkeys %}
+    <ul class="passkey-list">
+        {% for passkey in passkeys %}
+        <li>
+            <strong>{{ passkey.friendly_name }}</strong>
+            <span class="muted">
+                {% if passkey.backup_eligible %}sync-capable{% else %}device-bound{% endif %}
+                {% if passkey.backed_up %}, backed up{% endif %}
+                {% if passkey.created_at %} - added {{ passkey.created_at[:10] }}{% endif %}
+            </span>
+        </li>
+        {% endfor %}
+    </ul>
+    {% else %}
+    <p class="muted">No passkeys registered.</p>
+    {% endif %}
+</div>
+{% endblock %}

--- a/src/gamatrix/templates/modern/preferences.html.jinja
+++ b/src/gamatrix/templates/modern/preferences.html.jinja
@@ -1,0 +1,159 @@
+{% extends "base.html.jinja" %}
+{% block title %}gamatrix — preferences{% endblock %}
+{% block body %}
+<div class="topbar">
+    <h2>Preferences</h2>
+    <div class="right"><a href="/games">Back to games</a></div>
+</div>
+
+<form id="profile" method="post" action="/profile" class="filters"
+      hx-post="/profile" hx-swap="none"
+      hx-on::after-request="if(event.detail.successful){this.querySelector('.saved').style.display='inline';this.querySelector('.error').style.display='none'}else{const e=this.querySelector('.error');e.textContent=JSON.parse(event.detail.xhr.responseText).error;e.style.display='inline';this.querySelector('.saved').style.display='none'}">
+    <fieldset class="filter-group">
+        <legend>Display name</legend>
+        <label>
+            <input type="text" name="username" value="{{ user.username }}"
+                   maxlength="32" required>
+        </label>
+        <button type="submit">Save name</button>
+        <span class="saved muted" style="display:none;">Saved ✓</span>
+        <span class="error" style="display:none;color:#c00;"></span>
+    </fieldset>
+</form>
+
+<div id="profilepic" class="filters">
+    <fieldset class="filter-group">
+        <legend>Profile picture</legend>
+        {% set pu = pic_url(user) %}
+        <img class="pic-preview" width="48" height="48"
+             src="{{ pu or '/static/profile_img/question_block.jpg' }}">
+        <input type="file" id="pic-file" accept="image/*">
+        <button type="button" onclick="uploadProfilePic()">Upload</button>
+        <span class="saved muted" style="display:none;">Saved ✓</span>
+        <span class="error" style="display:none;color:#c00;"></span>
+    </fieldset>
+</div>
+<script>
+// Send the file as the raw request body so the server can size-cap it as it
+// streams, rather than receiving a fully-buffered multipart upload.
+async function uploadProfilePic() {
+    const box = document.getElementById('profilepic');
+    const saved = box.querySelector('.saved');
+    const error = box.querySelector('.error');
+    const file = document.getElementById('pic-file').files[0];
+    if (!file) { return; }
+    saved.style.display = 'none';
+    error.style.display = 'none';
+    let data = {};
+    try {
+        const resp = await fetch('/profile/pic', {
+            method: 'POST',
+            headers: {'Content-Type': file.type || 'application/octet-stream'},
+            body: file,
+        });
+        data = await resp.json().catch(() => ({}));
+        if (!resp.ok) { throw new Error(data.error || 'Upload failed.'); }
+    } catch (e) {
+        error.textContent = e.message || 'Upload failed.';
+        error.style.display = 'inline';
+        return;
+    }
+    if (data.pic_url) { box.querySelector('.pic-preview').src = data.pic_url; }
+    saved.style.display = 'inline';
+}
+
+function applyDisplayMode() {
+    const form = document.getElementById('filters');
+    const mode = form.querySelector('select[name="display_mode"]').value;
+    const saved = form.querySelector('.saved');
+    document.body.removeAttribute('data-mode');
+    if (mode !== 'system') {
+        document.body.dataset.mode = mode;
+    }
+    saved.textContent = 'Save preferences to keep change';
+    saved.style.display = 'inline';
+}
+</script>
+
+<div class="filters">
+    <fieldset class="filter-group">
+        <legend>Passkeys</legend>
+        <button type="button" onclick="window.location.href='/auth/passkeys'">Manage passkeys</button>
+        <span class="muted">Add, review, or remove passkeys for this account.</span>
+    </fieldset>
+
+    <fieldset class="filter-group">
+        <legend>API tokens</legend>
+        <button type="button" onclick="window.location.href='/auth/tokens'">Manage API tokens</button>
+        <span class="muted">Create tokens for unattended, scheduled DB uploads.</span>
+    </fieldset>
+</div>
+
+<form id="filters" method="post" action="/preferences" class="filters"
+      hx-post="/preferences" hx-swap="none"
+      hx-on::after-request="const s=this.querySelector('.saved');s.textContent='Saved ✓';s.style.display='inline'">
+
+    <fieldset class="filter-group">
+        <legend>Display mode</legend>
+        <span class="muted">Your browser preference is used until you choose a mode.</span>
+        <label>
+            <select name="display_mode">
+                <option value="system"{% if prefs.display_mode is none %} selected{% endif %}>System Setting</option>
+                {% for mode in ['light', 'dark', 'high-contrast', 'color-blind'] %}
+                <option value="{{ mode }}"{% if prefs.display_mode == mode %} selected{% endif %}>
+                    {{ mode|replace('-', ' ')|title }}
+                </option>
+                {% endfor %}
+            </select>
+        </label>
+    </fieldset>
+
+    <fieldset class="filter-group">
+        <legend>Default users</legend>
+        {% for uid, u in users.items() %}
+        <label>
+            <input type="checkbox" name="user" value="{{ uid }}"
+                {% if prefs.selected_users == 'all' or uid in prefs.selected_users %}checked{% endif %}>
+            {{ u.username }}
+        </label>
+        {% endfor %}
+    </fieldset>
+
+    <fieldset class="filter-group">
+        <legend>Default view</legend>
+        <label><input type="radio" name="view" value="list"
+            {% if prefs.default_view == 'list' %}checked{% endif %}> Game list</label>
+        <label><input type="radio" name="view" value="grid"
+            {% if prefs.default_view == 'grid' %}checked{% endif %}> Game grid</label>
+    </fieldset>
+
+    <fieldset class="filter-group">
+        <legend>Default options</legend>
+        <label><input type="checkbox" name="single_player" value="true"
+            {% if prefs.include_single_player %}checked{% endif %}> Include single-player</label>
+        <label><input type="checkbox" name="installed_only" value="true"
+            {% if prefs.installed_only %}checked{% endif %}> Installed only</label>
+        <label><input type="checkbox" name="exclusive" value="true"
+            {% if prefs.exclusive %}checked{% endif %}> Exclusively owned</label>
+        <label><input type="checkbox" name="show_keys" value="true"
+            {% if prefs.show_keys %}checked{% endif %}> Show product keys</label>
+    </fieldset>
+
+    <fieldset class="filter-group">
+        <legend>Exclude platforms</legend>
+        <div class="platform-grid">
+            {% for p in platforms %}
+            <label><input type="checkbox" name="exclude" value="{{ p }}"
+                {% if p in prefs.exclude_platforms %}checked{% endif %}> {{ p|capitalize }}</label>
+            {% endfor %}
+        </div>
+    </fieldset>
+
+    <fieldset class="filter-group">
+        <legend>&nbsp;</legend>
+        <button type="button" onclick="applyDisplayMode()">Apply</button>
+        <button type="submit">Save preferences</button>
+        <span class="saved muted" style="display:none;">Saved ✓</span>
+    </fieldset>
+</form>
+{% endblock %}

--- a/src/gamatrix/templates/modern/tokens.html.jinja
+++ b/src/gamatrix/templates/modern/tokens.html.jinja
@@ -1,0 +1,167 @@
+{% extends "base.html.jinja" %}
+{% block title %}gamatrix — API tokens{% endblock %}
+{% block body %}
+<div class="topbar">
+    <h2>API tokens</h2>
+    <div class="right"><a href="/preferences">Back to preferences</a></div>
+</div>
+
+<div class="card wide">
+    <h3>Unattended uploads</h3>
+    <p class="muted">An API token lets a scheduled task upload your GOG Galaxy
+    database automatically, with no browser login. Treat it like a password:
+    anyone holding it can replace your library. Create one per machine so you can
+    revoke them individually.</p>
+    <form id="token-create">
+        <label for="token_name">Token name</label>
+        <input type="text" id="token_name" name="name" maxlength="64"
+               value="Scheduled upload" required>
+        <label for="token_password">Current password
+            <span class="help-icon"
+                  title="Required to verify your identity before creating a token"
+                  aria-label="Required to verify your identity before creating a token"
+                  tabindex="0">?</span>
+        </label>
+        <input type="password" id="token_password" name="password" required
+               autocomplete="current-password">
+        <button type="submit">Create token</button>
+    </form>
+    <p id="token-error" class="error" hidden></p>
+</div>
+
+<div class="card wide" id="token-reveal" hidden>
+    <h3>Your new token</h3>
+    <p class="error">Copy it now — for your security it is never shown again.</p>
+    <pre id="token-value" class="token-box"></pre>
+    <button type="button" id="copy-token">Copy token</button>
+
+    <h4>Set it up on Windows (PowerShell)</h4>
+    <p class="muted">Paste this into a PowerShell window. It saves the token so
+    only your Windows account can read it, downloads the uploader, and schedules
+    a daily upload.</p>
+    <pre id="token-snippet" class="token-box"></pre>
+    <button type="button" id="copy-snippet">Copy setup script</button>
+    <p class="muted">On macOS or Linux, download
+    <a href="{{ base_url }}/auth/upload-gamatrix.sh">upload-gamatrix.sh</a>,
+    save the token to a file only you can read
+    (<code>chmod 600 ~/.gamatrix-token</code>), and run the script from cron.
+    It needs <code>curl</code> and <code>python3</code> on the
+    <code>PATH</code> — <code>python3</code> is not installed by default on
+    macOS, some Linux distros, or many WSL setups, so install it first if
+    <code>python3 --version</code> fails.</p>
+</div>
+
+<div class="card wide">
+    <h3>Active tokens</h3>
+    <div id="token-list" hx-get="/auth/tokens/list" hx-trigger="load">…</div>
+</div>
+
+<script>
+(function () {
+    const form = document.getElementById("token-create");
+    const errorEl = document.getElementById("token-error");
+    const reveal = document.getElementById("token-reveal");
+    const tokenEl = document.getElementById("token-value");
+    const snippetEl = document.getElementById("token-snippet");
+
+    function reloadList() {
+        htmx.ajax("GET", "/auth/tokens/list", { target: "#token-list" });
+    }
+
+    // Last-used times are stored as UTC. Rewrite each one in the viewer's local
+    // time zone; toLocaleString() picks up the browser's locale and zone
+    // automatically. The list is fetched and re-fetched via HTMX, so run this
+    // after every swap into #token-list.
+    function localizeLastUsed() {
+        for (const el of document.querySelectorAll(".token-last-used[data-last-used]")) {
+            const iso = el.dataset.lastUsed;
+            if (!iso) { continue; }
+            const when = new Date(iso);
+            if (isNaN(when)) { continue; }
+            el.textContent = when.toLocaleString();
+        }
+    }
+    document.body.addEventListener("htmx:afterSwap", (event) => {
+        if (event.target.id === "token-list") { localizeLastUsed(); }
+    });
+
+    async function copy(text, button) {
+        try {
+            await navigator.clipboard.writeText(text);
+            const original = button.textContent;
+            button.textContent = "Copied ✓";
+            setTimeout(() => { button.textContent = original; }, 1500);
+        } catch (e) { /* clipboard blocked; user can select manually */ }
+    }
+
+    form.addEventListener("submit", async (event) => {
+        event.preventDefault();
+        errorEl.hidden = true;
+        const data = new FormData(form);
+        const response = await fetch("/auth/tokens", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+                name: data.get("name"),
+                password: data.get("password"),
+            }),
+        });
+        if (!response.ok) {
+            const body = await response.json().catch(() => ({}));
+            errorEl.textContent = body.detail || "Could not create token.";
+            errorEl.hidden = false;
+            return;
+        }
+        const body = await response.json();
+        tokenEl.textContent = body.token;
+        snippetEl.textContent = body.snippet;
+        reveal.hidden = false;
+        form.querySelector("#token_password").value = "";
+        reveal.scrollIntoView({ behavior: "smooth" });
+        reloadList();
+    });
+
+    document.getElementById("copy-token").addEventListener("click", (e) =>
+        copy(tokenEl.textContent, e.currentTarget));
+    document.getElementById("copy-snippet").addEventListener("click", (e) =>
+        copy(snippetEl.textContent, e.currentTarget));
+
+    // Tokens load asynchronously, so delegate revoke handling. The password is
+    // entered in an inline (masked) field rather than a clear-text prompt.
+    const list = document.getElementById("token-list");
+
+    list.addEventListener("click", (event) => {
+        if (event.target.closest(".delete-token")) {
+            const li = event.target.closest("li");
+            li.querySelector(".delete-token").hidden = true;
+            const confirm = li.querySelector(".revoke-confirm");
+            confirm.hidden = false;
+            confirm.querySelector(".revoke-password").focus();
+        } else if (event.target.closest(".revoke-cancel")) {
+            const li = event.target.closest("li");
+            li.querySelector(".revoke-confirm").hidden = true;
+            li.querySelector(".delete-token").hidden = false;
+        }
+    });
+
+    list.addEventListener("submit", async (event) => {
+        const form = event.target.closest(".revoke-confirm");
+        if (!form) return;
+        event.preventDefault();
+        const password = form.querySelector(".revoke-password").value;
+        if (!password) return;
+        const response = await fetch(`/auth/tokens/${form.dataset.tokenId}`, {
+            method: "DELETE",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ password: password }),
+        });
+        if (response.ok) {
+            reloadList();
+        } else {
+            const body = await response.json().catch(() => ({}));
+            alert(body.detail || "Could not revoke token.");
+        }
+    });
+})();
+</script>
+{% endblock %}

--- a/src/gamatrix/templates/modern/tokens_list.html.jinja
+++ b/src/gamatrix/templates/modern/tokens_list.html.jinja
@@ -1,0 +1,28 @@
+{% if tokens %}
+<ul class="token-list">
+    {% for t in tokens %}
+    <li>
+        <strong>{{ t.name }}</strong>
+        <span class="muted">
+            {% if t.created_at %}added {{ t.created_at[:10] }}{% endif %}
+            {# Server stores last_used_at as UTC; the text here is a no-JS
+               fallback that the script in tokens.html.jinja rewrites in the
+               viewer's local time. #}
+            {% if t.last_used_at %}· last used <span class="token-last-used"
+                  data-last-used="{{ t.last_used_at }}">{{ t.last_used_at[:10] }}</span>{% else %}· never used{% endif %}
+        </span>
+        <button type="button" class="secondary delete-token"
+                data-token-id="{{ t.token_id }}">Revoke</button>
+        <form class="revoke-confirm" data-token-id="{{ t.token_id }}" hidden>
+            <input type="password" class="revoke-password" required
+                   autocomplete="current-password"
+                   placeholder="Current password to revoke">
+            <button type="submit" class="secondary">Confirm</button>
+            <button type="button" class="revoke-cancel">Cancel</button>
+        </form>
+    </li>
+    {% endfor %}
+</ul>
+{% else %}
+<p class="muted">No tokens yet.</p>
+{% endif %}

--- a/src/gamatrix/templates/modern/upload.html.jinja
+++ b/src/gamatrix/templates/modern/upload.html.jinja
@@ -1,0 +1,43 @@
+{% extends "base.html.jinja" %}
+{% block title %}gamatrix — upload DB{% endblock %}
+{% block body %}
+<div class="topbar">
+    <h2>Upload your GOG Galaxy database</h2>
+    <div class="right"><a href="/games">Back to games</a></div>
+</div>
+
+<div class="card" style="max-width:540px; margin:1rem 0;">
+    <p>Your GOG Galaxy DB is usually at:</p>
+    <p><code>C:\ProgramData\GOG.com\Galaxy\storage\galaxy-2.0.db</code></p>
+    <input type="file" id="dbfile" accept=".db">
+    <button id="uploadBtn" type="button">Upload</button>
+    <p id="status" class="muted"></p>
+    <p class="muted">Want this to happen automatically on a schedule?
+    Set up <a href="/auth/tokens">an API token for unattended uploads</a>.</p>
+</div>
+
+<script>
+const statusEl = document.getElementById('status');
+
+document.getElementById('uploadBtn').addEventListener('click', async () => {
+    const file = document.getElementById('dbfile').files[0];
+    if (!file) { statusEl.textContent = 'Choose a file first.'; return; }
+
+    statusEl.textContent = 'Requesting upload URL…';
+    const presign = await fetch('/upload/presign').then(r => r.json());
+
+    const form = new FormData();
+    for (const [k, v] of Object.entries(presign.fields)) form.append(k, v);
+    form.append('file', file);
+
+    statusEl.textContent = 'Uploading…';
+    const put = await fetch(presign.url, { method: 'POST', body: form });
+    if (!put.ok) { statusEl.textContent = 'Upload failed.'; return; }
+
+    statusEl.textContent = 'Processing database…';
+    const done = await fetch('/upload/complete', { method: 'POST' }).then(r => r.json());
+    statusEl.textContent = 'Done! Your library has been updated. Redirecting…';
+    setTimeout(() => window.location = '/games', 1500);
+});
+</script>
+{% endblock %}

--- a/src/gamatrix/templating.py
+++ b/src/gamatrix/templating.py
@@ -1,4 +1,4 @@
-"""Stable public and default authenticated Jinja environments."""
+"""Stable public and deployment-selected authenticated Jinja environments."""
 
 from __future__ import annotations
 
@@ -9,6 +9,7 @@ from starlette.background import BackgroundTask
 from starlette.responses import Response
 
 from gamatrix import __version__
+from gamatrix.config import get_settings
 from gamatrix.constants import PLATFORMS
 from gamatrix.games.preferences import merge_preferences
 from gamatrix.helpers import pic_url
@@ -26,6 +27,7 @@ AUTHENTICATED_TEMPLATE_NAMES = (
     "tokens_list.html.jinja",
     "upload.html.jinja",
 )
+UX_TEMPLATES = ("default", "modern")
 templates = Jinja2Templates(directory=str(TEMPLATES_DIR))
 
 
@@ -37,9 +39,16 @@ def _configure(environment: Jinja2Templates) -> Jinja2Templates:
 
 
 _configure(templates)
-authenticated_templates = _configure(
-    Jinja2Templates(directory=str(TEMPLATES_DIR / "default"))
-)
+
+
+def build_authenticated_templates(template_name: str) -> Jinja2Templates:
+    """Build an environment for a validated deployment-selected UX template."""
+    if template_name not in UX_TEMPLATES:
+        raise ValueError(f"Unknown UX template: {template_name}")
+    return _configure(Jinja2Templates(directory=str(TEMPLATES_DIR / template_name)))
+
+
+authenticated_templates = build_authenticated_templates(get_settings().ux_template)
 
 
 def authenticated_template(

--- a/src/gamatrix/templating.py
+++ b/src/gamatrix/templating.py
@@ -7,7 +7,6 @@ from starlette.background import BackgroundTask
 from starlette.responses import Response
 
 from gamatrix import __version__
-from gamatrix.config import get_settings
 from gamatrix.constants import PLATFORMS
 from gamatrix.games.preferences import merge_preferences
 from gamatrix.helpers import pic_url
@@ -30,6 +29,7 @@ AUTHENTICATED_TEMPLATE_NAMES = (
     "upload.html.jinja",
 )
 templates = Jinja2Templates(directory=str(TEMPLATES_DIR))
+_authenticated_templates: Jinja2Templates | None = None
 
 
 def _configure(environment: Jinja2Templates) -> Jinja2Templates:
@@ -48,7 +48,28 @@ def build_authenticated_templates(template_name: str) -> Jinja2Templates:
     return _configure(Jinja2Templates(directory=str(TEMPLATES_DIR / template_name)))
 
 
-authenticated_templates = build_authenticated_templates(get_settings().ux_template)
+def configure_authenticated_templates(template_name: str) -> Jinja2Templates:
+    """Configure the authenticated template environment for the running app."""
+
+    global _authenticated_templates
+    _authenticated_templates = build_authenticated_templates(template_name)
+    return _authenticated_templates
+
+
+def get_authenticated_templates() -> Jinja2Templates:
+    """Return the authenticated template environment chosen during app startup.
+
+    App initialization must call ``configure_authenticated_templates()`` once
+    with the validated runtime ``ux_template`` setting before any authenticated
+    render helpers are used.
+    """
+
+    if _authenticated_templates is None:
+        raise RuntimeError(
+            "Authenticated templates are not configured. "
+            "Call configure_authenticated_templates() during app initialization."
+        )
+    return _authenticated_templates
 
 
 def authenticated_template(
@@ -63,7 +84,7 @@ def authenticated_template(
     """Render an authenticated page or fragment with the account's saved mode."""
     user = context.get("user") or {}
     mode = merge_preferences(user.get("preferences", {})).get("display_mode")
-    return authenticated_templates.TemplateResponse(
+    return get_authenticated_templates().TemplateResponse(
         request,
         name,
         {**context, "display_mode": mode},
@@ -84,7 +105,7 @@ def authenticated_fragment(
     background: BackgroundTask | None = None,
 ) -> Response:
     """Render an authenticated fragment without base-layout display-mode wiring."""
-    return authenticated_templates.TemplateResponse(
+    return get_authenticated_templates().TemplateResponse(
         request,
         name,
         context,

--- a/src/gamatrix/templating.py
+++ b/src/gamatrix/templating.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from pathlib import Path
-
 from fastapi.templating import Jinja2Templates
 from starlette.background import BackgroundTask
 from starlette.responses import Response
@@ -13,8 +11,12 @@ from gamatrix.config import get_settings
 from gamatrix.constants import PLATFORMS
 from gamatrix.games.preferences import merge_preferences
 from gamatrix.helpers import pic_url
+from gamatrix.ux_templates import (
+    TEMPLATES_DIR,
+    UX_TEMPLATES,
+    canonicalize_ux_template_name,
+)
 
-TEMPLATES_DIR = Path(__file__).parent / "templates"
 AUTHENTICATED_TEMPLATE_NAMES = (
     "base.html.jinja",
     "games.html.jinja",
@@ -27,7 +29,6 @@ AUTHENTICATED_TEMPLATE_NAMES = (
     "tokens_list.html.jinja",
     "upload.html.jinja",
 )
-UX_TEMPLATES = ("default", "modern")
 templates = Jinja2Templates(directory=str(TEMPLATES_DIR))
 
 
@@ -43,8 +44,7 @@ _configure(templates)
 
 def build_authenticated_templates(template_name: str) -> Jinja2Templates:
     """Build an environment for a validated deployment-selected UX template."""
-    if template_name not in UX_TEMPLATES:
-        raise ValueError(f"Unknown UX template: {template_name}")
+    template_name = canonicalize_ux_template_name(template_name)
     return _configure(Jinja2Templates(directory=str(TEMPLATES_DIR / template_name)))
 
 

--- a/src/gamatrix/ux_templates.py
+++ b/src/gamatrix/ux_templates.py
@@ -1,0 +1,71 @@
+"""Discovery and validation helpers for deployment-selectable UX templates.
+
+This module inspects the shipped template directories under ``src/gamatrix/
+templates`` and treats explicit marker files there as the source of truth for
+valid ``UX_TEMPLATE`` values. The helpers normalize user-supplied names to the
+canonical on-disk directory name and fail fast when a configured template is not
+present in the shipped product.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+TEMPLATES_DIR = Path(__file__).parent / "templates"
+STATIC_TEMPLATES_DIR = Path(__file__).parent / "static" / "templates"
+DEFAULT_UX_TEMPLATE = "default"
+VALID_TEMPLATE_MARKER = "valid_template"
+
+
+def _is_ux_template_dir(path: Path) -> bool:
+    """Return whether ``path`` looks like a shipped authenticated UX template.
+
+    Valid UX template directories are real subdirectories of ``TEMPLATES_DIR``
+    that opt in via an explicit marker file. This keeps discovery tied to
+    shipped assets without inferring validity from incidental file names or
+    directory naming conventions.
+    """
+
+    return path.is_dir() and (path / VALID_TEMPLATE_MARKER).is_file()
+
+
+def discover_ux_templates(template_root: Path = TEMPLATES_DIR) -> tuple[str, ...]:
+    """Return the canonical UX template names shipped with the application."""
+
+    template_names = tuple(
+        sorted(
+            path.name for path in template_root.iterdir() if _is_ux_template_dir(path)
+        )
+    )
+    if not template_names:
+        raise RuntimeError(f"No UX templates found under {template_root}")
+    return template_names
+
+
+def canonicalize_ux_template_name(
+    template_name: str, template_root: Path = TEMPLATES_DIR
+) -> str:
+    """Normalize ``template_name`` to a discovered canonical directory name.
+
+    Matching is case-insensitive so deploy-time or environment configuration can
+    use ``MODERN`` and still resolve to the shipped ``modern`` directory. Any
+    value that does not correspond to a discovered template directory is
+    rejected with the current valid options listed in the error.
+    """
+
+    if not isinstance(template_name, str):
+        raise ValueError("ux_template must be a string")
+
+    valid_templates = discover_ux_templates(template_root)
+    valid_by_casefold = {name.casefold(): name for name in valid_templates}
+    canonical_name = valid_by_casefold.get(template_name.casefold())
+    if canonical_name is None:
+        valid_list = ", ".join(valid_templates)
+        raise ValueError(
+            "ux_template must match one of the shipped template directories: "
+            f"{valid_list}"
+        )
+    return canonical_name
+
+
+UX_TEMPLATES = discover_ux_templates()

--- a/tests/test_cdk_config.py
+++ b/tests/test_cdk_config.py
@@ -74,3 +74,26 @@ def test_load_deploy_config_requires_alias_hosted_zone(tmp_path, monkeypatch):
 
     with pytest.raises(ValueError, match="alias_hosted_zone"):
         config.load_deploy_config()
+
+
+def test_load_deploy_config_reads_ux_template(tmp_path, monkeypatch):
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    (config_dir / "cdk-config.yaml").write_text("ux_template: modern")
+    monkeypatch.setenv("GAMATRIX_CONFIG_DIR", str(config_dir))
+
+    config = _load_cdk_config_module()
+
+    assert config.load_deploy_config().ux_template == "modern"
+
+
+def test_load_deploy_config_rejects_unknown_ux_template(tmp_path, monkeypatch):
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    (config_dir / "cdk-config.yaml").write_text("ux_template: ../../outside")
+    monkeypatch.setenv("GAMATRIX_CONFIG_DIR", str(config_dir))
+
+    config = _load_cdk_config_module()
+
+    with pytest.raises(ValueError, match="ux_template"):
+        config.load_deploy_config()

--- a/tests/test_cdk_config.py
+++ b/tests/test_cdk_config.py
@@ -79,7 +79,7 @@ def test_load_deploy_config_requires_alias_hosted_zone(tmp_path, monkeypatch):
 def test_load_deploy_config_reads_ux_template(tmp_path, monkeypatch):
     config_dir = tmp_path / "config"
     config_dir.mkdir()
-    (config_dir / "cdk-config.yaml").write_text("ux_template: modern")
+    (config_dir / "cdk-config.yaml").write_text("ux_template: MODERN")
     monkeypatch.setenv("GAMATRIX_CONFIG_DIR", str(config_dir))
 
     config = _load_cdk_config_module()

--- a/tests/test_cdk_passkeys.py
+++ b/tests/test_cdk_passkeys.py
@@ -74,6 +74,7 @@ def test_stack_creates_passkey_tables_ttl_gsi_and_rp_environment(monkeypatch):
                     {
                         "WEBAUTHN_RP_ID": "games.example.com",
                         "WEBAUTHN_ORIGINS": '["https://games.example.com"]',
+                        "UX_TEMPLATE": "default",
                     }
                 )
             }

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -40,6 +40,11 @@ def test_ux_template_defaults_to_default(monkeypatch):
     assert s.ux_template == "default"
 
 
+def test_ux_template_is_normalized_case_insensitively():
+    s = Settings(local_dev=True, ux_template="MODERN")
+    assert s.ux_template == "modern"
+
+
 def test_unknown_ux_template_is_rejected():
     with pytest.raises(ValueError, match="ux_template"):
         Settings(local_dev=True, ux_template="unknown")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -29,6 +29,22 @@ def test_local_dev_defaults_to_documented_local_base_url():
     assert s.app_base_url == "http://localhost:8088"
 
 
+def test_ux_template_defaults_to_default(monkeypatch):
+    monkeypatch.delenv("UX_TEMPLATE", raising=False)
+    s = Settings(
+        local_dev=True,
+        jwt_secret=DEFAULT_JWT_SECRET,
+        jwt_secret_name=None,
+        _env_file=None,
+    )
+    assert s.ux_template == "default"
+
+
+def test_unknown_ux_template_is_rejected():
+    with pytest.raises(ValueError, match="ux_template"):
+        Settings(local_dev=True, ux_template="unknown")
+
+
 def test_secret_name_satisfies_production_guard():
     s = Settings(
         local_dev=False,

--- a/tests/test_games.py
+++ b/tests/test_games.py
@@ -4,8 +4,15 @@ from __future__ import annotations
 
 import pytest
 
-from gamatrix.games.service import ComparisonQuery, SortSpec, compare
+from gamatrix.constants import JOB_RUNNING
+from gamatrix.games.service import (
+    ComparisonQuery,
+    SortSpec,
+    compare,
+    ensure_enrichment_job,
+)
 from gamatrix.helpers import now_iso
+from gamatrix.storage.queue import EnrichmentQueue
 
 
 @pytest.fixture
@@ -283,3 +290,96 @@ def test_owned_scope_lists_all_selected_users_games(populated):
     )
     titles = {g.title for g in result.items}
     assert titles == {"Coop Game", "Solo Game", "Shared MP"}
+
+
+def test_ensure_enrichment_job_reuses_active_job(repo, settings):
+    repo.put_job(
+        {
+            "job_id": "live-job",
+            "status": JOB_RUNNING,
+            "created_at": now_iso(),
+            "updated_at": now_iso(),
+            "completed_at": None,
+            "release_keys": ["steam_10"],
+            "total": 1,
+            "completed_count": 0,
+        }
+    )
+
+    job_id = ensure_enrichment_job(
+        repo,
+        EnrichmentQueue(settings=settings),
+        ComparisonQuery(selected_user_ids=["1"]),
+        settings=settings,
+    )
+
+    assert job_id == "live-job"
+
+
+def test_ensure_enrichment_job_creates_job_for_stale_selected_games(repo, settings):
+    repo.put_user({"email": "a@x.com", "username": "A", "user_id": "1"})
+    repo.put_game(
+        {
+            "release_key": "steam_10",
+            "title": "Needs Refresh",
+            "slug": "needs-refresh",
+            "igdb_key": "steam_10",
+            "platform": "steam",
+            "multiplayer": True,
+            "max_players": 4,
+            "rating": 0,
+            "game_modes": [],
+            "enrichment_status": "pending",
+            "enriched_at": None,
+        }
+    )
+    repo.replace_user_library(
+        "1", [{"release_key": "steam_10", "platform": "steam", "installed": False}]
+    )
+
+    job_id = ensure_enrichment_job(
+        repo,
+        EnrichmentQueue(settings=settings),
+        ComparisonQuery(selected_user_ids=["1"]),
+        settings=settings,
+    )
+
+    assert job_id is not None
+    job = repo.get_job(job_id)
+    assert job is not None
+    assert job["release_keys"] == ["steam_10"]
+    assert job["total"] == 1
+
+
+def test_ensure_enrichment_job_returns_none_when_selected_games_are_fresh(
+    repo, settings
+):
+    repo.put_user({"email": "a@x.com", "username": "A", "user_id": "1"})
+    repo.put_game(
+        {
+            "release_key": "steam_10",
+            "title": "Fresh Game",
+            "slug": "fresh-game",
+            "igdb_key": "steam_10",
+            "platform": "steam",
+            "multiplayer": True,
+            "max_players": 4,
+            "rating": 0,
+            "game_modes": [],
+            "enrichment_status": "done",
+            "enriched_at": now_iso(),
+        }
+    )
+    repo.replace_user_library(
+        "1", [{"release_key": "steam_10", "platform": "steam", "installed": False}]
+    )
+
+    job_id = ensure_enrichment_job(
+        repo,
+        EnrichmentQueue(settings=settings),
+        ComparisonQuery(selected_user_ids=["1"]),
+        settings=settings,
+    )
+
+    assert job_id is None
+    assert repo.get_active_job() is None

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -56,7 +56,8 @@ def test_each_stylesheet_defines_every_required_mode_and_stays_small():
 
 
 def test_default_preferences_template_includes_apply_preview_controls():
-    html = authenticated_templates.env.get_template("preferences.html.jinja").render(
+    environment = build_authenticated_templates("default")
+    html = environment.env.get_template("preferences.html.jinja").render(
         user={"email": "user@x.com", "username": "User", "user_id": "1"},
         users={"1": {"username": "User", "user_id": "1"}},
         prefs=merge_preferences({"display_mode": None}),
@@ -68,13 +69,15 @@ def test_default_preferences_template_includes_apply_preview_controls():
 
 
 def test_default_token_templates_preserve_management_ui():
-    html = authenticated_templates.env.get_template("tokens.html.jinja").render(
-        base_url="https://games.example.com"
-    )
-    fragment = authenticated_templates.env.get_template(
-        "tokens_list.html.jinja"
-    ).render(tokens=[])
-    assert 'id="token-create"' in html
-    assert "/auth/tokens/list" in html
-    assert "/auth/upload-gamatrix.sh" in html
-    assert "No tokens yet." in fragment
+    for ux_template in UX_TEMPLATES:
+        environment = build_authenticated_templates(ux_template)
+        html = environment.env.get_template("tokens.html.jinja").render(
+            base_url="https://games.example.com"
+        )
+        fragment = environment.env.get_template("tokens_list.html.jinja").render(
+            tokens=[]
+        )
+        assert 'id="token-create"' in html
+        assert "/auth/tokens/list" in html
+        assert "/auth/upload-gamatrix.sh" in html
+        assert "No tokens yet." in fragment

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -5,13 +5,15 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
-from gamatrix.games.preferences import DISPLAY_MODES, merge_preferences
 from gamatrix.templating import (
     AUTHENTICATED_TEMPLATE_NAMES,
     TEMPLATES_DIR,
-    authenticated_templates,
+    UX_TEMPLATES,
+    build_authenticated_templates,
     templates,
 )
+from gamatrix.games.preferences import DISPLAY_MODES
+from gamatrix.games.preferences import merge_preferences
 
 
 def test_stylesheet_link_is_cache_busted():
@@ -21,28 +23,36 @@ def test_stylesheet_link_is_cache_busted():
     assert re.search(r'href="/static/style\.css\?v=[^"]+"', html)
 
 
-def test_default_authenticated_ux_has_the_complete_template_contract():
-    for name in AUTHENTICATED_TEMPLATE_NAMES:
-        authenticated_templates.env.get_template(name)
+def test_each_authenticated_ux_has_the_complete_template_contract():
+    for ux_template in UX_TEMPLATES:
+        environment = build_authenticated_templates(ux_template)
+        for name in AUTHENTICATED_TEMPLATE_NAMES:
+            environment.env.get_template(name)
 
 
-def test_default_authenticated_base_uses_cache_busted_stylesheet():
-    html = authenticated_templates.env.get_template("base.html.jinja").render()
-    assert "/static/templates/default/style.css?v=" in html
+def test_authenticated_bases_use_their_own_cache_busted_stylesheet():
+    for ux_template in UX_TEMPLATES:
+        environment = build_authenticated_templates(ux_template)
+        html = environment.env.get_template("base.html.jinja").render()
+        expected = f"/static/templates/{ux_template}/style.css?v="
+        assert expected in html
 
 
 def test_authenticated_templates_apply_only_valid_explicit_modes():
-    template = authenticated_templates.env.get_template("base.html.jinja")
+    environment = build_authenticated_templates("modern")
+    template = environment.env.get_template("base.html.jinja")
     assert 'data-mode="dark"' in template.render(display_mode="dark")
     assert "data-mode" not in template.render(display_mode=None)
 
 
-def test_default_stylesheet_defines_every_required_mode_and_stays_small():
-    path = Path(TEMPLATES_DIR.parent / "static" / "templates" / "default" / "style.css")
-    css = path.read_text()
-    assert path.stat().st_size < 20_000
-    for mode in DISPLAY_MODES:
-        assert f'data-mode="{mode}"' in css
+def test_each_stylesheet_defines_every_required_mode_and_stays_small():
+    static_root = TEMPLATES_DIR.parent / "static" / "templates"
+    for ux_template in UX_TEMPLATES:
+        path = Path(static_root / ux_template / "style.css")
+        css = path.read_text()
+        assert path.stat().st_size < 20_000
+        for mode in DISPLAY_MODES:
+            assert f'data-mode="{mode}"' in css
 
 
 def test_default_preferences_template_includes_apply_preview_controls():

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -7,13 +7,17 @@ from pathlib import Path
 
 from gamatrix.templating import (
     AUTHENTICATED_TEMPLATE_NAMES,
-    TEMPLATES_DIR,
     UX_TEMPLATES,
     build_authenticated_templates,
     templates,
 )
 from gamatrix.games.preferences import DISPLAY_MODES
 from gamatrix.games.preferences import merge_preferences
+from gamatrix.ux_templates import (
+    STATIC_TEMPLATES_DIR,
+    VALID_TEMPLATE_MARKER,
+    discover_ux_templates,
+)
 
 
 def test_stylesheet_link_is_cache_busted():
@@ -28,6 +32,19 @@ def test_each_authenticated_ux_has_the_complete_template_contract():
         environment = build_authenticated_templates(ux_template)
         for name in AUTHENTICATED_TEMPLATE_NAMES:
             environment.env.get_template(name)
+
+
+def test_authenticated_ux_templates_are_discovered_from_shipped_directories():
+    assert UX_TEMPLATES == discover_ux_templates()
+
+
+def test_discover_ux_templates_requires_valid_template_marker(tmp_path):
+    (tmp_path / "marked").mkdir()
+    (tmp_path / "marked" / VALID_TEMPLATE_MARKER).write_text("")
+    (tmp_path / "unmarked").mkdir()
+    (tmp_path / "unmarked" / "base.html.jinja").write_text("")
+
+    assert discover_ux_templates(tmp_path) == ("marked",)
 
 
 def test_authenticated_bases_use_their_own_cache_busted_stylesheet():
@@ -45,10 +62,15 @@ def test_authenticated_templates_apply_only_valid_explicit_modes():
     assert "data-mode" not in template.render(display_mode=None)
 
 
+def test_authenticated_templates_accept_case_insensitive_names():
+    environment = build_authenticated_templates("MODERN")
+    html = environment.env.get_template("base.html.jinja").render()
+    assert "/static/templates/modern/style.css?v=" in html
+
+
 def test_each_stylesheet_defines_every_required_mode_and_stays_small():
-    static_root = TEMPLATES_DIR.parent / "static" / "templates"
     for ux_template in UX_TEMPLATES:
-        path = Path(static_root / ux_template / "style.css")
+        path = Path(STATIC_TEMPLATES_DIR / ux_template / "style.css")
         css = path.read_text()
         assert path.stat().st_size < 20_000
         for mode in DISPLAY_MODES:

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+import types
 from pathlib import Path
 
 from gamatrix.templating import (
@@ -88,6 +89,46 @@ def test_default_preferences_template_includes_apply_preview_controls():
     assert "function applyDisplayMode()" in html
     assert "Save preferences to keep change" in html
     assert "s.textContent='Saved ✓'" in html
+
+
+def test_games_templates_localize_user_db_updated_tooltips():
+    opts = types.SimpleNamespace(
+        selected_user_ids=["1"],
+        include_single_player=False,
+        installed_only=False,
+        exclusive=False,
+        randomize=False,
+        show_keys=False,
+        exclude_platforms=[],
+    )
+    users = {
+        "1": {
+            "username": "User",
+            "user_id": "1",
+            "db_updated_at": "2026-06-09T04:28:54+00:00",
+        },
+        "2": {"username": "Never", "user_id": "2"},
+    }
+
+    for ux_template in UX_TEMPLATES:
+        environment = build_authenticated_templates(ux_template)
+        html = environment.env.get_template("games.html.jinja").render(
+            user={"email": "user@x.com", "username": "Viewer", "user_id": "9"},
+            users=users,
+            opts=opts,
+            is_grid=False,
+            platforms=[],
+            job_id=None,
+            job=None,
+            games=[],
+            caption="",
+        )
+        assert 'class="user-db-updated"' in html
+        assert 'data-db-updated="2026-06-09T04:28:54+00:00"' in html
+        assert 'title="DB updated: loading local time..."' in html
+        assert 'title="DB updated: never"' in html
+        assert "function localizeDbUpdatedTooltips()" in html
+        assert "when.toLocaleString()" in html
 
 
 def test_default_token_templates_preserve_management_ui():

--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -9,6 +9,7 @@ from gamatrix import upload
 from gamatrix.app import app
 from gamatrix.auth import service, tokens
 from gamatrix.auth.dependencies import get_repo
+from gamatrix.config import get_settings
 
 
 # ---------------------------------------------------------------------------
@@ -98,7 +99,8 @@ def test_create_token_returns_secret_and_setup_snippet(repo):
         _login(client)
         management = client.get("/auth/tokens")
         assert management.status_code == 200
-        assert "/static/templates/default/style.css?v=" in management.text
+        expected = f'/static/templates/{get_settings().ux_template}/style.css?v='
+        assert expected in management.text
         created = client.post(
             "/auth/tokens", json={"name": "laptop", "password": "password"}
         )

--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -99,7 +99,7 @@ def test_create_token_returns_secret_and_setup_snippet(repo):
         _login(client)
         management = client.get("/auth/tokens")
         assert management.status_code == 200
-        expected = f'/static/templates/{get_settings().ux_template}/style.css?v='
+        expected = f"/static/templates/{get_settings().ux_template}/style.css?v="
         assert expected in management.text
         created = client.post(
             "/auth/tokens", json={"name": "laptop", "password": "password"}


### PR DESCRIPTION
_Change [3 / 3] to get updated UX in place for Gamatrix: [Preview of the hotness is here](https://github.com/user-attachments/assets/c738d157-c53c-45a0-99d3-1dc1b4d92390)_

Add a new 'modern' template - final state with a fully-template-able UX for Gamatrix. All modes are supported and the entire 

### What

Adds a second authenticated template, `modern`, and makes the deployment choose between `default` and `modern`. This keeps the data and display-mode work from earlier PRs intact while introducing the new visual layer as an additive change.

### How

Added `templates/modern/` and its stylesheet, then generalized the authenticated templating setup to validate and load the configured UX template. Runtime and CDK config now pass `UX_TEMPLATE` through deployment, with tests covering template selection and config validation.

Change your template by setting `UX_TEMPLATE=modern` in your .env file prior to deployment. Values are: `default` or `modern`.
