### PR TITLE
Make modern "Dark" mode use the pre-template (2.3.x) palette

### DIFF
--- a/src/gamatrix/static/templates/modern/style.css
+++ b/src/gamatrix/static/templates/modern/style.css
@@ -18,37 +18,46 @@ body[data-mode="light"] {
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --page: #111b20;
-    --surface: #19272d;
-    --surface-alt: #22333a;
-    --text: #e4edf0;
-    --muted: #aabcc3;
-    --border: #49616a;
-    --accent: #6ed7df;
-    --accent-text: #102329;
-    --row-a: #19272d;
-    --row-b: #203239;
-    --owned: #28573e;
-    --unowned: #673c3c;
-    --warning: #ffd166;
+    --page: rgb(50, 50, 50);
+    --surface: #3c3c3c;
+    --surface-alt: #4a4a4a;
+    --text: lightgray;
+    --muted: #aaaaaa;
+    --border: #555555;
+    --accent: rgb(124, 207, 228);
+    --accent-text: #102027;
+    --row-a: rgb(180, 227, 239);
+    --row-b: rgb(201, 235, 243);
+    --owned: rgb(182, 215, 168);
+    --unowned: rgb(234, 153, 153);
+    --warning: grey;
   }
+  /* Only flip the table body text when no explicit mode is chosen (system
+     follows the OS). An explicit choice is handled by its own block below,
+     so this must not leak into e.g. high-contrast while the OS is dark. */
+  body:not([data-mode]) table.results tbody tr { color: var(--accent-text); }
 }
 
+/* Dark mode uses the pre-template (2.3.x) palette: a dark page chrome with the
+   original light-blue results table. v1 paired a dark page with *light* rows and
+   dark cell text, so the table body text is flipped back to dark below while the
+   page chrome keeps the light --text. */
 body[data-mode="dark"] {
-  --page: #111b20;
-  --surface: #19272d;
-  --surface-alt: #22333a;
-  --text: #e4edf0;
-  --muted: #aabcc3;
-  --border: #49616a;
-  --accent: #6ed7df;
-  --accent-text: #102329;
-  --row-a: #19272d;
-  --row-b: #203239;
-  --owned: #28573e;
-  --unowned: #673c3c;
-  --warning: #ffd166;
+  --page: rgb(50, 50, 50);
+  --surface: #3c3c3c;
+  --surface-alt: #4a4a4a;
+  --text: lightgray;
+  --muted: #aaaaaa;
+  --border: #555555;
+  --accent: rgb(124, 207, 228);
+  --accent-text: #102027;
+  --row-a: rgb(180, 227, 239);
+  --row-b: rgb(201, 235, 243);
+  --owned: rgb(182, 215, 168);
+  --unowned: rgb(234, 153, 153);
+  --warning: grey;
 }
+body[data-mode="dark"] table.results tbody tr { color: var(--accent-text); }
 
 body[data-mode="high-contrast"] {
   --page: #000000;


### PR DESCRIPTION
### What

Repoints the **modern** template's existing **Dark** mode at the color scheme Gamatrix used before the templating framework was introduced (e.g. `2.3.3`): a dark page with the original light-blue results table, green/red ownership cells, and light-cyan accents.

No new mode — selecting **Dark** in Preferences (or having an OS dark preference) now gives the v1 look.

### How

Single file: `static/templates/modern/style.css`.

- `body[data-mode="dark"]` palette swapped from the previous modern dark (dark rows, light text) to the v1 palette (dark page, **light** rows, dark cell text).
- Because v1 inverts modern's text/row relationship, one extra rule flips the **table body** text back to dark so it stays readable on the light-blue rows; the page chrome keeps the light body text.
- The `@media (prefers-color-scheme: dark)` system default is updated to the same palette, keeping the two dark triggers in sync as the stylesheet already did. Its text-flip is guarded with `body:not([data-mode])` so it only applies to the system case and never leaks into an explicit non-dark mode (e.g. high-contrast) while the OS is dark.

### Notes

- Per your direction, this replaces the earlier approach of adding a separate `v1-dark` mode — `DISPLAY_MODES`, the preference dropdowns, and the `default` stylesheet are all back to their master state; the diff is now just the modern stylesheet.
- I updated **both** the explicit-Dark block and the system-dark `@media` block so "Dark" looks the same however it's triggered (they were already kept identical). If you only wanted the explicit `data-mode="dark"` choice changed and the system default left as the old modern dark, say the word and I'll narrow it.
- Faithful-to-v1 quirk carried over: a game with a manual `url` renders a light-cyan title link on a light-blue row (low contrast), exactly as v1 did.

### Testing

- `uv run pytest` — 155 passed (mode-contract + preference tests included).
- Verified `base.html.jinja` renders `<body data-mode="dark">` and the modern stylesheet stays well under the 20 KB budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)