### PR TITLE
Speed up comparison sort and filtering

### DIFF
--- a/src/gamatrix/config.py
+++ b/src/gamatrix/config.py
@@ -74,6 +74,13 @@ class Settings(BaseSettings):
     igdb_stale_days: int = 30
     ux_template: str = DEFAULT_UX_TEMPLATE
 
+    # How long the Repository serves the comparison read-model (users, games,
+    # libraries, metadata overrides) from its in-process cache before re-reading
+    # from DynamoDB. Lets repeated filter changes reuse one set of reads. Writes
+    # invalidate the relevant cache entry in-process, so the only staleness is
+    # across separate processes (e.g. an upload/enrich Lambda) until expiry.
+    read_cache_ttl_seconds: float = 60.0
+
     # SSM parameter names for the title filter lists (AWS only). Locally these
     # are seeded into DynamoDB config and read from there.
     hidden_games_param: str = "/gamatrix/hidden-games"

--- a/src/gamatrix/games/routes.py
+++ b/src/gamatrix/games/routes.py
@@ -19,7 +19,6 @@ from gamatrix.constants import (
 )
 from gamatrix.games import api, service, web
 from gamatrix.games.preferences import merge_preferences
-from gamatrix.games.web import WebCompareOptions
 from gamatrix.jobs import create_enrichment_job, is_job_stale
 from gamatrix.storage.dynamo import Repository
 from gamatrix.storage.queue import get_queue

--- a/src/gamatrix/games/service.py
+++ b/src/gamatrix/games/service.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from dataclasses import asdict, dataclass, field, replace
 from datetime import datetime, timedelta, timezone
-from typing import Iterable, Literal, Protocol
+from typing import Literal, Protocol
 
 from gamatrix.config import Settings, get_settings
 from gamatrix.constants import (
@@ -48,7 +48,7 @@ class ComparisonRepository(Protocol):
 
     def get_user_library(self, user_id: str) -> list[dict]: ...
 
-    def batch_get_games(self, release_keys: Iterable[str]) -> dict[str, dict]: ...
+    def get_all_games_map(self) -> dict[str, dict]: ...
 
     def get_all_metadata(self) -> dict[str, dict]: ...
 
@@ -116,7 +116,7 @@ def compare(repo: ComparisonRepository, query: ComparisonQuery) -> ComparisonDat
             if entry.get("installed"):
                 slot["installed"].add(user_id)
 
-    metadata = repo.batch_get_games(agg.keys())
+    metadata = repo.get_all_games_map()
     overrides = repo.get_all_metadata()
 
     games: list[ComparisonItem] = []

--- a/src/gamatrix/static/games_sort.js
+++ b/src/gamatrix/static/games_sort.js
@@ -1,0 +1,93 @@
+// Client-side column sorting for the games results table.
+//
+// The full result set is already in the DOM, so sorting a column is just a
+// reorder of existing <tr> rows — no server round-trip. Each row carries the
+// sort keys as data-sort-<col> attributes; each sortable header carries
+// data-sort-col and data-sort-type ("text" or "num"). The server still renders
+// the initial order, so this is pure progressive enhancement.
+//
+// A single delegated listener on document survives HTMX swaps that replace the
+// table when filters change, so there is nothing to re-bind after a swap.
+(function () {
+    "use strict";
+
+    function cellValue(row, col, type) {
+        const raw = row.getAttribute("data-sort-" + col) || "";
+        if (type === "num") {
+            const n = parseFloat(raw);
+            return isNaN(n) ? 0 : n;
+        }
+        return raw.toLowerCase();
+    }
+
+    function nextDirection(th) {
+        // First click on a column sorts ascending; clicking the active
+        // ascending column flips to descending. Mirrors the old server logic.
+        return th.getAttribute("aria-sort") === "ascending"
+            ? "descending"
+            : "ascending";
+    }
+
+    function updateIndicators(thead, activeTh, direction) {
+        for (const th of thead.querySelectorAll("th.sortable")) {
+            const arrow = th.querySelector(".sort-arrow");
+            if (th === activeTh) {
+                th.setAttribute("aria-sort", direction);
+                if (arrow) {
+                    arrow.textContent = direction === "ascending" ? "▲" : "▼";
+                }
+            } else {
+                th.removeAttribute("aria-sort");
+                if (arrow) {
+                    arrow.textContent = "";
+                }
+            }
+        }
+    }
+
+    function sortTable(table, th) {
+        const col = th.getAttribute("data-sort-col");
+        const type = th.getAttribute("data-sort-type") || "text";
+        const direction = nextDirection(th);
+        const factor = direction === "ascending" ? 1 : -1;
+
+        const tbody = table.tBodies[0];
+        if (!tbody) {
+            return;
+        }
+
+        const rows = Array.prototype.slice.call(tbody.rows);
+        rows.sort(function (a, b) {
+            const av = cellValue(a, col, type);
+            const bv = cellValue(b, col, type);
+            if (av < bv) {
+                return -1 * factor;
+            }
+            if (av > bv) {
+                return 1 * factor;
+            }
+            return 0;
+        });
+
+        // Re-appending an existing node moves it, so this reorders in place.
+        const frag = document.createDocumentFragment();
+        for (const row of rows) {
+            frag.appendChild(row);
+        }
+        tbody.appendChild(frag);
+
+        updateIndicators(th.closest("thead"), th, direction);
+    }
+
+    document.addEventListener("click", function (event) {
+        const th = event.target.closest("th.sortable");
+        if (!th) {
+            return;
+        }
+        const table = th.closest("table.results");
+        if (!table) {
+            return;
+        }
+        sortTable(table, th);
+    });
+})();

--- a/src/gamatrix/storage/dynamo.py
+++ b/src/gamatrix/storage/dynamo.py
@@ -8,6 +8,7 @@ dynamodb-local in development; only the endpoint URL differs.
 from __future__ import annotations
 
 import decimal
+import time
 from typing import TYPE_CHECKING, Any, Iterable, cast
 
 import boto3
@@ -52,9 +53,37 @@ class Repository:
             region_name=self.settings.aws_region,
             endpoint_url=self.settings.dynamodb_endpoint_url,
         )
+        # Short-TTL cache for the comparison read-model so repeated filter/sort
+        # requests reuse one set of reads. Entries are keyed by name; per-user
+        # libraries use "library:<user_id>". Writes invalidate the affected key
+        # so the cache never serves data this process itself just changed.
+        self._cache: dict[str, tuple[float, Any]] = {}
 
     def _table(self, name: str):
         return self._resource.Table(name)
+
+    # ------------------------------------------------------------------
+    # read-model cache
+    # ------------------------------------------------------------------
+    def _cache_get(self, key: str) -> Any | None:
+        entry = self._cache.get(key)
+        if entry is None:
+            return None
+        expires_at, value = entry
+        if time.monotonic() >= expires_at:
+            self._cache.pop(key, None)
+            return None
+        return value
+
+    def _cache_put(self, key: str, value: Any) -> Any:
+        ttl = self.settings.read_cache_ttl_seconds
+        if ttl > 0:
+            self._cache[key] = (time.monotonic() + ttl, value)
+        return value
+
+    def _cache_invalidate(self, *keys: str) -> None:
+        for key in keys:
+            self._cache.pop(key, None)
 
     # ------------------------------------------------------------------
     # games
@@ -84,8 +113,23 @@ class Repository:
                 result[game["release_key"]] = game
         return result
 
+    def get_all_games_map(self) -> dict[str, dict]:
+        """Cached full games table keyed by release_key.
+
+        The comparison service looks up metadata for whatever release keys the
+        selected libraries contain. Serving every lookup from one cached scan
+        replaces the per-request chain of BatchGetItem calls and lets repeated
+        filter/sort changes hit memory instead of DynamoDB.
+        """
+        cached = self._cache_get("games_map")
+        if cached is not None:
+            return cached
+        games = {g["release_key"]: g for g in self._scan(self.settings.games_table)}
+        return self._cache_put("games_map", games)
+
     def put_game(self, game: dict) -> None:
         self._table(self.settings.games_table).put_item(Item=_to_dynamo(game))
+        self._cache_invalidate("games_map")
 
     def scan_all_games(self) -> list[dict]:
         return self._scan(self.settings.games_table)
@@ -108,14 +152,19 @@ class Repository:
         return None
 
     def scan_users(self) -> list[dict]:
-        return self._scan(self.settings.users_table)
+        cached = self._cache_get("users")
+        if cached is not None:
+            return cached
+        return self._cache_put("users", self._scan(self.settings.users_table))
 
     def put_user(self, user: dict) -> None:
         user = {**user, "email": user["email"].lower()}
         self._table(self.settings.users_table).put_item(Item=_to_dynamo(user))
+        self._cache_invalidate("users")
 
     def delete_user(self, email: str) -> None:
         self._table(self.settings.users_table).delete_item(Key={"email": email.lower()})
+        self._cache_invalidate("users")
 
     def purge_user_account(self, user: dict) -> None:
         """Remove a user row and its user-owned local artifacts.
@@ -145,6 +194,7 @@ class Repository:
             ExpressionAttributeValues={":v": user_handle},
             ReturnValues="ALL_NEW",
         )
+        self._cache_invalidate("users")
         return str(response["Attributes"]["webauthn_user_id"])
 
     def update_user(self, email: str, attrs: dict) -> None:
@@ -159,18 +209,27 @@ class Repository:
             ExpressionAttributeNames=names,
             ExpressionAttributeValues=values,
         )
+        self._cache_invalidate("users")
 
     # ------------------------------------------------------------------
     # user_libraries  (PK user_id, SK release_key)
     # ------------------------------------------------------------------
     def get_user_library(self, user_id: str) -> list[dict]:
-        return self._query_all(
+        key = f"library:{user_id}"
+        cached = self._cache_get(key)
+        if cached is not None:
+            return cached
+        rows = self._query_all(
             self.settings.libraries_table,
             KeyConditionExpression=Key("user_id").eq(str(user_id)),
         )
+        return self._cache_put(key, rows)
 
     def replace_user_library(self, user_id: str, entries: list[dict]) -> None:
         """Delete the user's existing library rows and write the new set."""
+        # Drop any cached copy so the read below sees current rows, and so later
+        # comparison reads pick up the replacement once writes land.
+        self._cache_invalidate(f"library:{user_id}")
         table = self._table(self.settings.libraries_table)
         existing = self.get_user_library(user_id)
         incoming: dict[str, dict] = {}
@@ -200,9 +259,11 @@ class Repository:
             for entry in incoming.values():
                 item = {**entry, "user_id": str(user_id)}
                 batch.put_item(Item=_to_dynamo(item))
+        self._cache_invalidate(f"library:{user_id}")
 
     def clear_user_library(self, user_id: str) -> int:
         """Delete every library row for a user. Returns the number removed."""
+        self._cache_invalidate(f"library:{user_id}")
         table = self._table(self.settings.libraries_table)
         existing = self.get_user_library(user_id)
         with table.batch_writer() as batch:
@@ -210,6 +271,7 @@ class Repository:
                 batch.delete_item(
                     Key={"user_id": str(user_id), "release_key": row["release_key"]}
                 )
+        self._cache_invalidate(f"library:{user_id}")
         return len(existing)
 
     def get_owners_of_release(self, release_key: str) -> list[str]:
@@ -310,10 +372,15 @@ class Repository:
     # metadata_overrides  (PK slug)
     # ------------------------------------------------------------------
     def get_all_metadata(self) -> dict[str, dict]:
-        return {m["slug"]: m for m in self._scan(self.settings.metadata_table)}
+        cached = self._cache_get("metadata")
+        if cached is not None:
+            return cached
+        overrides = {m["slug"]: m for m in self._scan(self.settings.metadata_table)}
+        return self._cache_put("metadata", overrides)
 
     def put_metadata(self, override: dict) -> None:
         self._table(self.settings.metadata_table).put_item(Item=_to_dynamo(override))
+        self._cache_invalidate("metadata")
 
     def clear_metadata(self) -> int:
         """Delete every override row. Returns the number removed."""
@@ -322,6 +389,7 @@ class Repository:
         with table.batch_writer() as batch:
             for row in rows:
                 batch.delete_item(Key={"slug": row["slug"]})
+        self._cache_invalidate("metadata")
         return len(rows)
 
     # ------------------------------------------------------------------

--- a/src/gamatrix/templates/default/games.html.jinja
+++ b/src/gamatrix/templates/default/games.html.jinja
@@ -102,6 +102,7 @@
 <div id="games-container">
     {% include "games_table.html.jinja" %}
 </div>
+<script src="/static/games_sort.js"></script>
 <script>
 (function () {
     function localizeDbUpdatedTooltips() {

--- a/src/gamatrix/templates/default/games_table.html.jinja
+++ b/src/gamatrix/templates/default/games_table.html.jinja
@@ -1,13 +1,14 @@
 {# Renders the results table. Swapped in by HTMX on filter/sort changes. #}
+{# Columns sort in the browser (see /static/games_sort.js): clicking a header
+   reorders the rows already in the DOM, so no server round-trip is needed. The
+   server still renders the initial order from opts.sort/opts.direction. #}
 {% macro sort_header(label, col) %}
-    {% set next_dir = 'desc' if (opts.sort == col and opts.direction == 'asc') else 'asc' %}
-    <th hx-get="/games/table?sort={{ col }}&dir={{ next_dir }}"
-        hx-include="#filters"
-        hx-target="#games-container">
+    {% set is_active = opts.sort == col %}
+    <th class="sortable" data-sort-col="{{ col }}"
+        data-sort-type="{{ 'text' if col == 'title' else 'num' }}"
+        {% if is_active %}aria-sort="{{ 'ascending' if opts.direction == 'asc' else 'descending' }}"{% endif %}>
         {{ label }}
-        {% if opts.sort == col %}
-        <span class="sort-arrow">{{ '▲' if opts.direction == 'asc' else '▼' }}</span>
-        {% endif %}
+        <span class="sort-arrow">{% if is_active %}{{ '▲' if opts.direction == 'asc' else '▼' }}{% endif %}</span>
     </th>
 {% endmacro %}
 
@@ -41,7 +42,11 @@
     <tbody>
     {% for game in games %}
         {% set mp = game.max_players|default(0)|int %}
-        <tr class="{{ 'subthreshold' if (mp > 0 and mp < selected|length) else '' }}">
+        <tr class="{{ 'subthreshold' if (mp > 0 and mp < selected|length) else '' }}"
+            data-sort-title="{{ game.slug }}"
+            data-sort-players="{{ mp }}"
+            data-sort-rating="{{ game.rating|default(0) }}"
+            data-sort-installed="{{ game.installed|length }}">
             <td>
                 {% if game.url %}<a href="{{ game.url }}">{{ game.title }}</a>
                 {% else %}{{ game.title }}{% endif %}

--- a/src/gamatrix/templates/modern/games.html.jinja
+++ b/src/gamatrix/templates/modern/games.html.jinja
@@ -102,6 +102,7 @@
 <div id="games-container">
     {% include "games_table.html.jinja" %}
 </div>
+<script src="/static/games_sort.js"></script>
 <script>
 (function () {
     function localizeDbUpdatedTooltips() {

--- a/src/gamatrix/templates/modern/games_table.html.jinja
+++ b/src/gamatrix/templates/modern/games_table.html.jinja
@@ -1,13 +1,14 @@
 {# Renders the results table. Swapped in by HTMX on filter/sort changes. #}
+{# Columns sort in the browser (see /static/games_sort.js): clicking a header
+   reorders the rows already in the DOM, so no server round-trip is needed. The
+   server still renders the initial order from opts.sort/opts.direction. #}
 {% macro sort_header(label, col) %}
-    {% set next_dir = 'desc' if (opts.sort == col and opts.direction == 'asc') else 'asc' %}
-    <th hx-get="/games/table?sort={{ col }}&dir={{ next_dir }}"
-        hx-include="#filters"
-        hx-target="#games-container">
+    {% set is_active = opts.sort == col %}
+    <th class="sortable" data-sort-col="{{ col }}"
+        data-sort-type="{{ 'text' if col == 'title' else 'num' }}"
+        {% if is_active %}aria-sort="{{ 'ascending' if opts.direction == 'asc' else 'descending' }}"{% endif %}>
         {{ label }}
-        {% if opts.sort == col %}
-        <span class="sort-arrow">{{ '▲' if opts.direction == 'asc' else '▼' }}</span>
-        {% endif %}
+        <span class="sort-arrow">{% if is_active %}{{ '▲' if opts.direction == 'asc' else '▼' }}{% endif %}</span>
     </th>
 {% endmacro %}
 
@@ -41,7 +42,11 @@
     <tbody>
     {% for game in games %}
         {% set mp = game.max_players|default(0)|int %}
-        <tr class="{{ 'subthreshold' if (mp > 0 and mp < selected|length) else '' }}">
+        <tr class="{{ 'subthreshold' if (mp > 0 and mp < selected|length) else '' }}"
+            data-sort-title="{{ game.slug }}"
+            data-sort-players="{{ mp }}"
+            data-sort-rating="{{ game.rating|default(0) }}"
+            data-sort-installed="{{ game.installed|length }}">
             <td>
                 {% if game.url %}<a href="{{ game.url }}">{{ game.title }}</a>
                 {% else %}{{ game.title }}{% endif %}

--- a/src/gamatrix/templating.py
+++ b/src/gamatrix/templating.py
@@ -12,7 +12,6 @@ from gamatrix.games.preferences import merge_preferences
 from gamatrix.helpers import pic_url
 from gamatrix.ux_templates import (
     TEMPLATES_DIR,
-    UX_TEMPLATES,
     canonicalize_ux_template_name,
 )
 

--- a/tests/test_repository_cache.py
+++ b/tests/test_repository_cache.py
@@ -1,0 +1,82 @@
+"""Tests for the Repository read-model cache.
+
+The comparison read-model (users, games, libraries, metadata overrides) is
+cached in-process so repeated filter/sort requests reuse one set of reads. The
+cache returns the same object instance on a hit, so identity (`is`) is a precise
+probe for "served from cache" vs "freshly read", and writes must invalidate the
+affected entry so the cache never serves data this process just changed.
+"""
+
+from __future__ import annotations
+
+
+def test_games_map_caches_until_a_game_is_written(repo):
+    repo.put_game({"release_key": "steam_1", "slug": "one", "title": "One"})
+
+    first = repo.get_all_games_map()
+    assert repo.get_all_games_map() is first  # cache hit -> same object
+
+    repo.put_game({"release_key": "steam_2", "slug": "two", "title": "Two"})
+
+    second = repo.get_all_games_map()
+    assert second is not first  # write invalidated the cache
+    assert set(second) == {"steam_1", "steam_2"}
+
+
+def test_scan_users_caches_until_a_user_is_written(repo):
+    repo.put_user({"email": "a@x.com", "username": "A", "user_id": "1"})
+
+    first = repo.scan_users()
+    assert repo.scan_users() is first
+
+    repo.put_user({"email": "b@x.com", "username": "B", "user_id": "2"})
+    assert repo.scan_users() is not first
+    assert {u["email"] for u in repo.scan_users()} == {"a@x.com", "b@x.com"}
+
+
+def test_user_library_caches_per_user_and_invalidates_on_replace(repo):
+    repo.replace_user_library("1", [{"release_key": "steam_1", "installed": False}])
+
+    first = repo.get_user_library("1")
+    assert repo.get_user_library("1") is first  # cache hit
+
+    # A different user has its own cache slot and is unaffected.
+    repo.replace_user_library("2", [{"release_key": "steam_9", "installed": True}])
+    assert repo.get_user_library("1") is first
+
+    repo.replace_user_library(
+        "1",
+        [
+            {"release_key": "steam_1", "installed": False},
+            {"release_key": "steam_2", "installed": True},
+        ],
+    )
+    refreshed = repo.get_user_library("1")
+    assert refreshed is not first
+    assert {row["release_key"] for row in refreshed} == {"steam_1", "steam_2"}
+
+
+def test_user_library_invalidates_on_clear(repo):
+    repo.replace_user_library("1", [{"release_key": "steam_1", "installed": False}])
+    assert repo.get_user_library("1")  # populate cache
+
+    repo.clear_user_library("1")
+    assert repo.get_user_library("1") == []
+
+
+def test_metadata_caches_until_an_override_is_written(repo):
+    repo.put_metadata({"slug": "one", "max_players": 4})
+
+    first = repo.get_all_metadata()
+    assert repo.get_all_metadata() is first
+
+    repo.put_metadata({"slug": "two", "max_players": 2})
+    assert repo.get_all_metadata() is not first
+    assert set(repo.get_all_metadata()) == {"one", "two"}
+
+
+def test_ttl_zero_disables_caching(repo):
+    repo.settings = repo.settings.model_copy(update={"read_cache_ttl_seconds": 0})
+    repo.put_game({"release_key": "steam_1", "slug": "one", "title": "One"})
+    # With caching off every read re-scans, so no two calls share identity.
+    assert repo.get_all_games_map() is not repo.get_all_games_map()

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -15,7 +15,7 @@ from starlette.datastructures import QueryParams
 
 from gamatrix.app import app
 from gamatrix.auth.dependencies import current_user_api, get_repo
-from gamatrix.games import routes, web
+from gamatrix.games import web
 
 
 def _opts(query_string: str, preferences: dict):

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -8,10 +8,10 @@ from pathlib import Path
 
 from gamatrix.templating import (
     AUTHENTICATED_TEMPLATE_NAMES,
-    UX_TEMPLATES,
     build_authenticated_templates,
     templates,
 )
+from gamatrix.ux_templates import UX_TEMPLATES
 from gamatrix.games.preferences import DISPLAY_MODES
 from gamatrix.games.preferences import merge_preferences
 from gamatrix.ux_templates import (


### PR DESCRIPTION
## Problem

Sorting a column with all ~2560 titles shown took **~4s**. Each column click fired a full `/games/table` HTMX request that re-ran the entire `compare()` pipeline against DynamoDB — user scan, per-user library queries, ~26 sequential `BatchGetItem` calls, a metadata scan — and re-rendered every row, just to reorder data the browser already had. Filter changes paid the same I/O cost.

## Changes

**1. Client-side sort (sort no longer touches the server)**
- `static/games_sort.js`: one delegated click listener reorders the `<tr>` rows already in the DOM via `data-sort-*` attributes. Survives HTMX swaps, so nothing to re-bind after a filter change.
- Both `games_table.html.jinja` templates: sort headers dropped `hx-get` and gained `class="sortable"` + `data-sort-col/-type` + `aria-sort`; rows carry `data-sort-title/players/rating/installed` (matching the old `SORT_KEYS`). The server still renders the initial order — pure progressive enhancement.

**2. 60s in-process read cache on the singleton `Repository`**
- New `Settings.read_cache_ttl_seconds` (default 60).
- TTL cache wrapping `scan_users`, `get_all_metadata`, per-user `get_user_library`, and a new `get_all_games_map` (one cached full-table scan replacing the per-request `BatchGetItem` chain in `compare()`).
- Every write path invalidates its key in-process (`put_game`, user writes, `replace_user_library`/`clear_user_library`, metadata writes).
- Filter changes become "cached reads + in-memory merge/filter" instead of re-scanning DynamoDB.

**3. flake8 cleanup**
- Removes three pre-existing unused imports (`routes.py`, `templating.py`, `test_routes.py`); `UX_TEMPLATES` is now imported in the test from its canonical module `ux_templates`.

## Tradeoff

Writes from the upload/enrich Lambdas only appear in the web process after its cache expires — up to the TTL (60s). Tune via `read_cache_ttl_seconds`.

## Testing

- `just check` green: black, flake8, mypy all clean.
- **161 tests pass** (155 existing + 6 new in `tests/test_repository_cache.py` covering cache hits, per-write invalidation, per-user isolation, and TTL=0 disabling the cache).

🤖 Generated with [Claude Code](https://claude.com/claude-code)