### PR TITLE
Add select-all toggles and invert platform filter to "Include"

### DIFF
--- a/src/gamatrix/games/web.py
+++ b/src/gamatrix/games/web.py
@@ -14,6 +14,7 @@ from typing import Literal
 
 from fastapi import Request
 
+from gamatrix.constants import PLATFORMS
 from gamatrix.games.preferences import merge_preferences
 from gamatrix.games.service import (
     ComparisonDataset,
@@ -73,11 +74,15 @@ def parse_options(
             return qp[name] in ("true", "on", "1")
         return False if form_submitted else default
 
-    def multi(name: str, default: list[str]) -> list[str]:
-        values = qp.getlist(name)
-        if values or form_submitted:
-            return values
-        return default
+    # Platforms are shown as an inclusive list ("Include platforms") with every
+    # box checked by default; translate the included set the form returns into
+    # the excluded set the comparison service expects. On a bare load, treat
+    # everything except the saved excludes as included.
+    if form_submitted:
+        included = set(qp.getlist("include"))
+    else:
+        included = set(PLATFORMS) - set(prefs["exclude_platforms"])
+    exclude_platforms = [p for p in PLATFORMS if p not in included]
 
     # User selection: checked `user` boxes win. On a bare load fall back to the
     # saved preference, expanding the "all" sentinel to every known user.
@@ -102,7 +107,7 @@ def parse_options(
         selected_user_ids=selected,
         include_single_player=flag("single_player", prefs["include_single_player"]),
         installed_only=flag("installed_only", prefs["installed_only"]),
-        exclude_platforms=multi("exclude", prefs["exclude_platforms"]),
+        exclude_platforms=exclude_platforms,
         exclusive=flag("exclusive", prefs["exclusive"]),
         view=view,
         randomize=flag("randomize", False),

--- a/src/gamatrix/preferences.py
+++ b/src/gamatrix/preferences.py
@@ -8,7 +8,11 @@ from fastapi import APIRouter, Depends, Request
 from fastapi.responses import HTMLResponse, JSONResponse, Response
 
 from gamatrix.auth.dependencies import current_user, current_user_api, get_repo
-from gamatrix.constants import DISPLAY_NAME_MAX_LENGTH, PROFILE_PIC_MAX_UPLOAD_SIZE
+from gamatrix.constants import (
+    DISPLAY_NAME_MAX_LENGTH,
+    PLATFORMS,
+    PROFILE_PIC_MAX_UPLOAD_SIZE,
+)
 from gamatrix.games.preferences import DISPLAY_MODES, merge_preferences
 from gamatrix.helpers import pic_url
 from gamatrix.images import process_profile_pic
@@ -68,6 +72,10 @@ async def save_preferences(
         return source.get(name) in ("true", "on", "1")
 
     selected = form.getlist("user") or qp.getlist("user")
+    # The platform control is an inclusive list ("Include platforms"); store the
+    # complement so the saved pref stays in the service's exclude vocabulary.
+    included = set(form.getlist("include") or qp.getlist("include"))
+    exclude_platforms = [p for p in PLATFORMS if p not in included]
     current = merge_preferences(user.get("preferences", {}))
     requested_mode = form.get("display_mode")
     if requested_mode == "system":
@@ -81,7 +89,7 @@ async def save_preferences(
         "installed_only": flag("installed_only"),
         "exclusive": flag("exclusive"),
         "show_keys": flag("show_keys"),
-        "exclude_platforms": form.getlist("exclude") or qp.getlist("exclude"),
+        "exclude_platforms": exclude_platforms,
         "default_view": form.get("view", qp.get("view", "list")),
         "selected_users": selected if selected else "all",
         "display_mode": display_mode,

--- a/src/gamatrix/static/templates/default/style.css
+++ b/src/gamatrix/static/templates/default/style.css
@@ -63,6 +63,7 @@ h1, h2 { font-weight: 600; }
 }
 .filters fieldset { border: none; margin: 0; padding: 0; }
 .filters legend { font-weight: 600; margin-bottom: 0.25rem; }
+.filters legend input.toggle-all { margin-right: 0.35rem; vertical-align: middle; }
 .filters label { display: inline-flex; align-items: center; gap: 4px; }
 .filter-group { display: flex; flex-direction: column; gap: 2px; }
 .platform-grid { display: grid; grid-template-columns: repeat(2, auto); gap: 2px 12px; }

--- a/src/gamatrix/static/templates/modern/style.css
+++ b/src/gamatrix/static/templates/modern/style.css
@@ -134,6 +134,7 @@ h1, h2, h3 { line-height: 1.15; }
 }
 .filters fieldset { min-width: 0; margin: 0; padding: 0; border: 0; }
 .filters legend { margin-bottom: .45rem; color: var(--accent); font-weight: bold; }
+.filters legend input.toggle-all { margin-right: .35rem; vertical-align: middle; }
 .filter-group { display: flex; flex-direction: column; gap: .3rem; }
 .filters label { display: flex; align-items: center; gap: .35rem; }
 .platform-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: .25rem; }

--- a/src/gamatrix/static/toggle_all.js
+++ b/src/gamatrix/static/toggle_all.js
@@ -1,0 +1,81 @@
+// "Select all / unselect all" master checkbox for grouped filter checkboxes.
+//
+// Any <fieldset> whose legend holds an <input class="toggle-all"> gets a
+// tri-state master: checked when every member is on, empty when none are, and
+// indeterminate (a dash) when only some are. Toggling the master flips every
+// member box in that fieldset.
+//
+// The filter form auto-refreshes on `change` (HTMX hx-trigger="change"), but
+// setting `.checked` in script does NOT fire `change`, so after a bulk toggle
+// we dispatch one bubbling `change` from the fieldset — a single server
+// round-trip rather than one per box. A single delegated listener on document
+// survives HTMX swaps, so there is nothing to re-bind.
+(function () {
+    "use strict";
+
+    function members(fieldset) {
+        return fieldset.querySelectorAll(
+            'input[type="checkbox"]:not(.toggle-all)'
+        );
+    }
+
+    function syncMaster(master) {
+        const fieldset = master.closest("fieldset");
+        if (!fieldset) {
+            return;
+        }
+        const boxes = members(fieldset);
+        let checked = 0;
+        for (const box of boxes) {
+            if (box.checked) {
+                checked++;
+            }
+        }
+        master.checked = boxes.length > 0 && checked === boxes.length;
+        master.indeterminate = checked > 0 && checked < boxes.length;
+    }
+
+    document.addEventListener("change", function (event) {
+        const target = event.target;
+        if (!(target instanceof HTMLInputElement)) {
+            return;
+        }
+        if (target.classList.contains("toggle-all")) {
+            const fieldset = target.closest("fieldset");
+            if (!fieldset) {
+                return;
+            }
+            for (const box of members(fieldset)) {
+                box.checked = target.checked;
+            }
+            target.indeterminate = false;
+            // One bubbling change so HTMX refetches the table just once.
+            fieldset.dispatchEvent(new Event("change", { bubbles: true }));
+            return;
+        }
+        if (target.type === "checkbox") {
+            const fieldset = target.closest("fieldset");
+            const master = fieldset
+                ? fieldset.querySelector("input.toggle-all")
+                : null;
+            if (master) {
+                syncMaster(master);
+            }
+        }
+    });
+
+    function initMasters() {
+        // `indeterminate` can't be set in HTML, so seed each master on load.
+        for (const master of document.querySelectorAll("input.toggle-all")) {
+            syncMaster(master);
+        }
+    }
+
+    if (document.readyState === "loading") {
+        document.addEventListener("DOMContentLoaded", initMasters, {
+            once: true,
+        });
+    } else {
+        initMasters();
+    }
+})();

--- a/src/gamatrix/static/toggle_all.js
+++ b/src/gamatrix/static/toggle_all.js
@@ -8,8 +8,15 @@
 // The filter form auto-refreshes on `change` (HTMX hx-trigger="change"), but
 // setting `.checked` in script does NOT fire `change`, so after a bulk toggle
 // we dispatch one bubbling `change` from the fieldset — a single server
-// round-trip rather than one per box. A single delegated listener on document
-// survives HTMX swaps, so there is nothing to re-bind.
+// round-trip rather than one per box.
+//
+// We listen in the CAPTURE phase (top-down) so we run before HTMX's listener on
+// the form, which is an ancestor of the master. The master's own native change
+// still carries the children's pre-toggle state, so we stop it there and let
+// only the fresh post-toggle event reach HTMX; otherwise the form would fire one
+// stale request and one correct one, and whichever lands last would win. A
+// single delegated listener on document survives HTMX swaps, so there is
+// nothing to re-bind.
 (function () {
     "use strict";
 
@@ -35,34 +42,41 @@
         master.indeterminate = checked > 0 && checked < boxes.length;
     }
 
-    document.addEventListener("change", function (event) {
-        const target = event.target;
-        if (!(target instanceof HTMLInputElement)) {
-            return;
-        }
-        if (target.classList.contains("toggle-all")) {
-            const fieldset = target.closest("fieldset");
-            if (!fieldset) {
+    document.addEventListener(
+        "change",
+        function (event) {
+            const target = event.target;
+            if (!(target instanceof HTMLInputElement)) {
                 return;
             }
-            for (const box of members(fieldset)) {
-                box.checked = target.checked;
+            if (target.classList.contains("toggle-all")) {
+                const fieldset = target.closest("fieldset");
+                if (!fieldset) {
+                    return;
+                }
+                // Suppress the master's native change (stale: the boxes below
+                // aren't flipped yet) before HTMX, on the form, can act on it.
+                event.stopPropagation();
+                for (const box of members(fieldset)) {
+                    box.checked = target.checked;
+                }
+                target.indeterminate = false;
+                // One fresh bubbling change so HTMX refetches the table once.
+                fieldset.dispatchEvent(new Event("change", { bubbles: true }));
+                return;
             }
-            target.indeterminate = false;
-            // One bubbling change so HTMX refetches the table just once.
-            fieldset.dispatchEvent(new Event("change", { bubbles: true }));
-            return;
-        }
-        if (target.type === "checkbox") {
-            const fieldset = target.closest("fieldset");
-            const master = fieldset
-                ? fieldset.querySelector("input.toggle-all")
-                : null;
-            if (master) {
-                syncMaster(master);
+            if (target.type === "checkbox") {
+                const fieldset = target.closest("fieldset");
+                const master = fieldset
+                    ? fieldset.querySelector("input.toggle-all")
+                    : null;
+                if (master) {
+                    syncMaster(master);
+                }
             }
-        }
-    });
+        },
+        true
+    );
 
     function initMasters() {
         // `indeterminate` can't be set in HTML, so seed each master on load.

--- a/src/gamatrix/templates/default/games.html.jinja
+++ b/src/gamatrix/templates/default/games.html.jinja
@@ -25,7 +25,7 @@
     <input type="hidden" name="filters_active" value="1">
 
     <fieldset class="filter-group">
-        <legend>Users</legend>
+        <legend><input type="checkbox" class="toggle-all" aria-label="Select all users"> Users</legend>
         {% for uid, u in users.items() %}
         {% set db_updated_at = u.get('db_updated_at') %}
         <label class="user-db-updated"
@@ -67,11 +67,11 @@
     </fieldset>
 
     <fieldset class="filter-group">
-        <legend>Exclude platforms</legend>
+        <legend><input type="checkbox" class="toggle-all" aria-label="Include all platforms"> Include platforms</legend>
         <div class="platform-grid">
             {% for p in platforms %}
-            <label><input type="checkbox" name="exclude" value="{{ p }}"
-                {% if p in opts.exclude_platforms %}checked{% endif %}>
+            <label><input type="checkbox" name="include" value="{{ p }}"
+                {% if p not in opts.exclude_platforms %}checked{% endif %}>
                 <img src="/static/{{ p }}.png" width="18" height="18"> {{ p|capitalize }}</label>
             {% endfor %}
         </div>
@@ -103,6 +103,7 @@
     {% include "games_table.html.jinja" %}
 </div>
 <script src="/static/games_sort.js"></script>
+<script src="/static/toggle_all.js"></script>
 <script>
 (function () {
     function localizeDbUpdatedTooltips() {

--- a/src/gamatrix/templates/default/preferences.html.jinja
+++ b/src/gamatrix/templates/default/preferences.html.jinja
@@ -109,7 +109,7 @@ function applyDisplayMode() {
     </fieldset>
 
     <fieldset class="filter-group">
-        <legend>Default users</legend>
+        <legend><input type="checkbox" class="toggle-all" aria-label="Select all users"> Default users</legend>
         {% for uid, u in users.items() %}
         <label>
             <input type="checkbox" name="user" value="{{ uid }}"
@@ -140,11 +140,11 @@ function applyDisplayMode() {
     </fieldset>
 
     <fieldset class="filter-group">
-        <legend>Exclude platforms</legend>
+        <legend><input type="checkbox" class="toggle-all" aria-label="Include all platforms"> Include platforms</legend>
         <div class="platform-grid">
             {% for p in platforms %}
-            <label><input type="checkbox" name="exclude" value="{{ p }}"
-                {% if p in prefs.exclude_platforms %}checked{% endif %}> {{ p|capitalize }}</label>
+            <label><input type="checkbox" name="include" value="{{ p }}"
+                {% if p not in prefs.exclude_platforms %}checked{% endif %}> {{ p|capitalize }}</label>
             {% endfor %}
         </div>
     </fieldset>
@@ -156,4 +156,5 @@ function applyDisplayMode() {
         <span class="saved muted" style="display:none;">Saved ✓</span>
     </fieldset>
 </form>
+<script src="/static/toggle_all.js"></script>
 {% endblock %}

--- a/src/gamatrix/templates/modern/games.html.jinja
+++ b/src/gamatrix/templates/modern/games.html.jinja
@@ -25,7 +25,7 @@
     <input type="hidden" name="filters_active" value="1">
 
     <fieldset class="filter-group">
-        <legend>Users</legend>
+        <legend><input type="checkbox" class="toggle-all" aria-label="Select all users"> Users</legend>
         {% for uid, u in users.items() %}
         {% set db_updated_at = u.get('db_updated_at') %}
         <label class="user-db-updated"
@@ -67,11 +67,11 @@
     </fieldset>
 
     <fieldset class="filter-group">
-        <legend>Exclude platforms</legend>
+        <legend><input type="checkbox" class="toggle-all" aria-label="Include all platforms"> Include platforms</legend>
         <div class="platform-grid">
             {% for p in platforms %}
-            <label><input type="checkbox" name="exclude" value="{{ p }}"
-                {% if p in opts.exclude_platforms %}checked{% endif %}>
+            <label><input type="checkbox" name="include" value="{{ p }}"
+                {% if p not in opts.exclude_platforms %}checked{% endif %}>
                 <img src="/static/{{ p }}.png" width="18" height="18"> {{ p|capitalize }}</label>
             {% endfor %}
         </div>
@@ -103,6 +103,7 @@
     {% include "games_table.html.jinja" %}
 </div>
 <script src="/static/games_sort.js"></script>
+<script src="/static/toggle_all.js"></script>
 <script>
 (function () {
     function localizeDbUpdatedTooltips() {

--- a/src/gamatrix/templates/modern/preferences.html.jinja
+++ b/src/gamatrix/templates/modern/preferences.html.jinja
@@ -109,7 +109,7 @@ function applyDisplayMode() {
     </fieldset>
 
     <fieldset class="filter-group">
-        <legend>Default users</legend>
+        <legend><input type="checkbox" class="toggle-all" aria-label="Select all users"> Default users</legend>
         {% for uid, u in users.items() %}
         <label>
             <input type="checkbox" name="user" value="{{ uid }}"
@@ -140,11 +140,11 @@ function applyDisplayMode() {
     </fieldset>
 
     <fieldset class="filter-group">
-        <legend>Exclude platforms</legend>
+        <legend><input type="checkbox" class="toggle-all" aria-label="Include all platforms"> Include platforms</legend>
         <div class="platform-grid">
             {% for p in platforms %}
-            <label><input type="checkbox" name="exclude" value="{{ p }}"
-                {% if p in prefs.exclude_platforms %}checked{% endif %}> {{ p|capitalize }}</label>
+            <label><input type="checkbox" name="include" value="{{ p }}"
+                {% if p not in prefs.exclude_platforms %}checked{% endif %}> {{ p|capitalize }}</label>
             {% endfor %}
         </div>
     </fieldset>
@@ -156,4 +156,5 @@ function applyDisplayMode() {
         <span class="saved muted" style="display:none;">Saved ✓</span>
     </fieldset>
 </form>
+<script src="/static/toggle_all.js"></script>
 {% endblock %}

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -15,7 +15,13 @@ from starlette.datastructures import QueryParams
 
 from gamatrix.app import app
 from gamatrix.auth.dependencies import current_user_api, get_repo
+from gamatrix.constants import PLATFORMS
 from gamatrix.games import web
+
+
+def _include_all() -> str:
+    """Query fragment with every platform's Include box checked."""
+    return "&".join(f"include={p}" for p in PLATFORMS)
 
 
 def _opts(query_string: str, preferences: dict):
@@ -60,18 +66,28 @@ def test_marker_applies_to_all_boolean_flags():
     assert opts.exclusive is False
 
 
-def test_emptied_exclude_list_clears_saved_pref():
-    """Submitting with every platform-exclude box unchecked clears the saved
+def test_all_included_clears_saved_exclude():
+    """Submitting with every Include-platform box checked clears the saved
     exclude list instead of falling back to it."""
     prefs = {"exclude_platforms": ["gog", "epic"], "selected_users": ["1"]}
-    opts = _opts("user=1&filters_active=1", prefs)
+    opts = _opts(f"user=1&filters_active=1&{_include_all()}", prefs)
     assert opts.exclude_platforms == []
 
 
-def test_partial_exclude_list_wins_over_saved_pref():
+def test_no_include_on_submit_excludes_all():
+    """Submitting with every Include-platform box unchecked excludes them all
+    (the inverse of the old all-unchecked-exclude case)."""
+    prefs = {"exclude_platforms": [], "selected_users": ["1"]}
+    opts = _opts("user=1&filters_active=1", prefs)
+    assert opts.exclude_platforms == list(PLATFORMS)
+
+
+def test_partial_include_excludes_the_rest():
+    """Only the checked platforms are kept; everything else is excluded, in the
+    canonical PLATFORMS order."""
     prefs = {"exclude_platforms": ["gog", "epic"], "selected_users": ["1"]}
-    opts = _opts("user=1&filters_active=1&exclude=gog", prefs)
-    assert opts.exclude_platforms == ["gog"]
+    opts = _opts("user=1&filters_active=1&include=steam&include=gog", prefs)
+    assert opts.exclude_platforms == [p for p in PLATFORMS if p not in {"steam", "gog"}]
 
 
 def test_bare_load_uses_saved_exclude_list():


### PR DESCRIPTION
## Summary

- Adds a **tri-state master checkbox** in the Users and platform group legends (checked = all on, empty = all off, dash = some on), so a whole group can be selected/cleared in one click — on both the games filter bar and the preferences page.
- **Inverts the platform control** to **"Include platforms"** with all boxes **checked by default**, which reads more naturally than the old negative "Exclude platforms".

## Implementation notes

- New `static/toggle_all.js`: generic vanilla-JS IIFE (matching `games_sort.js` conventions, delegated listener that survives HTMX swaps). A bulk toggle dispatches a single bubbling `change` so HTMX refetches the table just once.
- The Include→exclude inversion happens **only at the request boundary** (`games/web.py` `parse_options` and `preferences.py` `save_preferences`). The stored `exclude_platforms` pref key, `ComparisonQuery`, and the comparison service are unchanged — **no data migration**, existing saved preferences keep working.
- Default and modern template variants are kept byte-identical.
- Reworked the platform tests in `tests/test_routes.py` for the inverted semantics (all-checked → exclude nothing; none-checked → exclude all; partial → exclude the rest).

## Testing

- `just check` (black, flake8, mypy, pytest): **162 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)