### PR TITLE
Remove plain-text dialog in passkey revoke flow

### DIFF
--- a/src/gamatrix/auth/routes.py
+++ b/src/gamatrix/auth/routes.py
@@ -34,10 +34,6 @@ class CeremonyVerificationRequest(BaseModel):
     credential: dict
 
 
-class DeletePasskeyRequest(BaseModel):
-    password: str
-
-
 class CreateTokenRequest(BaseModel):
     password: str
     name: str
@@ -245,31 +241,6 @@ def passkey_authentication_verify(
         value=service.create_session_token(user["email"]), **_cookie_kwargs()
     )
     return response
-
-
-@router.delete("/passkeys/{credential_id}")
-def delete_passkey(
-    credential_id: str,
-    body: DeletePasskeyRequest,
-    user: dict = Depends(current_user_api),
-    repo: Repository = Depends(get_repo),
-):
-    if not service.authenticate(repo, user["email"], body.password):
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN, detail="Wrong password."
-        )
-    user_handle = user.get("webauthn_user_id")
-    if not user_handle:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="No passkeys are registered for this account.",
-        )
-    if not repo.delete_passkey(credential_id, user_handle):
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Passkey not found for this account.",
-        )
-    return {"deleted": True}
 
 
 def _token_setup_snippet(token: str) -> str:

--- a/src/gamatrix/auth/routes.py
+++ b/src/gamatrix/auth/routes.py
@@ -19,7 +19,11 @@ from gamatrix.auth.service import COOKIE_NAME
 from gamatrix.config import get_settings
 from gamatrix.constants import API_TOKEN_NAME_MAX_LENGTH
 from gamatrix.storage.dynamo import Repository
-from gamatrix.templating import authenticated_template, templates
+from gamatrix.templating import (
+    authenticated_fragment,
+    authenticated_template,
+    templates,
+)
 
 router = APIRouter(prefix="/auth", tags=["auth"])
 
@@ -143,7 +147,7 @@ def manage_passkeys_list(
     user: dict = Depends(current_user_api),
     repo: Repository = Depends(get_repo),
 ):
-    return templates.TemplateResponse(
+    return authenticated_fragment(
         request,
         "passkeys_manage_list.html.jinja",
         {"passkeys": _passkey_credentials(user, repo)},
@@ -157,7 +161,7 @@ def confirm_delete_passkey(
     user: dict = Depends(current_user_api),
     repo: Repository = Depends(get_repo),
 ):
-    return templates.TemplateResponse(
+    return authenticated_fragment(
         request,
         "passkey_delete_form.html.jinja",
         {"passkey": _owned_passkey(credential_id, user, repo), "error": None},
@@ -174,7 +178,7 @@ def delete_passkey_inline(
 ):
     passkey = _owned_passkey(credential_id, user, repo)
     if not service.authenticate(repo, user["email"], password):
-        return templates.TemplateResponse(
+        return authenticated_fragment(
             request,
             "passkey_delete_form.html.jinja",
             {"passkey": passkey, "error": "Wrong password."},
@@ -184,7 +188,7 @@ def delete_passkey_inline(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Passkey not found for this account.",
         )
-    return templates.TemplateResponse(
+    return authenticated_fragment(
         request,
         "passkeys_manage_list.html.jinja",
         {"passkeys": _passkey_credentials(user, repo)},

--- a/src/gamatrix/auth/routes.py
+++ b/src/gamatrix/auth/routes.py
@@ -99,6 +99,22 @@ def _passkey_credentials(user: dict, repo: Repository) -> list[dict]:
     return repo.list_passkeys(user_handle) if user_handle else []
 
 
+def _owned_passkey(credential_id: str, user: dict, repo: Repository) -> dict:
+    user_handle = user.get("webauthn_user_id")
+    if not user_handle:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="No passkeys are registered for this account.",
+        )
+    passkey = repo.get_passkey(credential_id)
+    if not passkey or passkey.get("user_handle") != user_handle:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Passkey not found for this account.",
+        )
+    return passkey
+
+
 @router.get("/passkeys", response_class=HTMLResponse)
 def passkey_management(
     request: Request,
@@ -122,6 +138,61 @@ def list_passkeys(
         request,
         "passkeys_list.html.jinja",
         {"user": user, "passkeys": _passkey_credentials(user, repo)},
+    )
+
+
+@router.get("/passkeys/manage/list", response_class=HTMLResponse)
+def manage_passkeys_list(
+    request: Request,
+    user: dict = Depends(current_user_api),
+    repo: Repository = Depends(get_repo),
+):
+    return templates.TemplateResponse(
+        request,
+        "passkeys_manage_list.html.jinja",
+        {"passkeys": _passkey_credentials(user, repo)},
+    )
+
+
+@router.get("/passkeys/{credential_id}/delete", response_class=HTMLResponse)
+def confirm_delete_passkey(
+    credential_id: str,
+    request: Request,
+    user: dict = Depends(current_user_api),
+    repo: Repository = Depends(get_repo),
+):
+    return templates.TemplateResponse(
+        request,
+        "passkey_delete_form.html.jinja",
+        {"passkey": _owned_passkey(credential_id, user, repo), "error": None},
+    )
+
+
+@router.post("/passkeys/{credential_id}/delete", response_class=HTMLResponse)
+def delete_passkey_inline(
+    credential_id: str,
+    request: Request,
+    password: str = Form(...),
+    user: dict = Depends(current_user_api),
+    repo: Repository = Depends(get_repo),
+):
+    passkey = _owned_passkey(credential_id, user, repo)
+    if not service.authenticate(repo, user["email"], password):
+        return templates.TemplateResponse(
+            request,
+            "passkey_delete_form.html.jinja",
+            {"passkey": passkey, "error": "Wrong password."},
+        )
+    if not repo.delete_passkey(credential_id, user["webauthn_user_id"]):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Passkey not found for this account.",
+        )
+    return templates.TemplateResponse(
+        request,
+        "passkeys_manage_list.html.jinja",
+        {"passkeys": _passkey_credentials(user, repo)},
+        headers={"HX-Retarget": "#passkey-list", "HX-Reswap": "outerHTML"},
     )
 
 

--- a/src/gamatrix/static/passkeys.js
+++ b/src/gamatrix/static/passkeys.js
@@ -133,22 +133,6 @@
         showError(error);
       }
     });
-    document.querySelectorAll(".delete-passkey").forEach((button) => {
-      button.addEventListener("click", async () => {
-        const password = window.prompt("Confirm your current password to delete this passkey:");
-        if (!password) return;
-        try {
-          await json(`/auth/passkeys/${encodeURIComponent(button.dataset.credentialId)}`, {
-            method: "DELETE",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ password: password }),
-          });
-          window.location.reload();
-        } catch (error) {
-          showError(error);
-        }
-      });
-    });
   }
 
   window.gamatrixPasskeys = { enableLogin, enableManagement };

--- a/src/gamatrix/static/style.css
+++ b/src/gamatrix/static/style.css
@@ -140,10 +140,6 @@ table.results td.unowned { background-color: var(--unowned); }
   display: flex; gap: 1rem; align-items: center; margin: 0.75rem 0;
 }
 .passkey-list li .muted, .token-list li .muted { flex: 1; }
-.passkey-delete-confirm { align-items: flex-start !important; flex-direction: column; }
-.passkey-delete-confirm form { display: flex; flex-wrap: wrap; gap: 0.5rem; align-items: center; width: 100%; }
-.passkey-delete-confirm label { display: flex; gap: 0.5rem; align-items: center; }
-.passkey-delete-confirm input[type=password] { padding: 6px; border-radius: 4px; border: 1px solid #888; }
 .token-box {
   white-space: pre-wrap;
   word-break: break-all;

--- a/src/gamatrix/static/style.css
+++ b/src/gamatrix/static/style.css
@@ -140,6 +140,10 @@ table.results td.unowned { background-color: var(--unowned); }
   display: flex; gap: 1rem; align-items: center; margin: 0.75rem 0;
 }
 .passkey-list li .muted, .token-list li .muted { flex: 1; }
+.passkey-delete-confirm { align-items: flex-start !important; flex-direction: column; }
+.passkey-delete-confirm form { display: flex; flex-wrap: wrap; gap: 0.5rem; align-items: center; width: 100%; }
+.passkey-delete-confirm label { display: flex; gap: 0.5rem; align-items: center; }
+.passkey-delete-confirm input[type=password] { padding: 6px; border-radius: 4px; border: 1px solid #888; }
 .token-box {
   white-space: pre-wrap;
   word-break: break-all;

--- a/src/gamatrix/static/templates/default/style.css
+++ b/src/gamatrix/static/templates/default/style.css
@@ -167,6 +167,10 @@ table.results td.unowned { background-color: var(--unowned); }
   display: flex; gap: 1rem; align-items: center; margin: 0.75rem 0;
 }
 .passkey-list li .muted, .token-list li .muted { flex: 1; }
+.passkey-delete-confirm { align-items: flex-start !important; flex-direction: column; }
+.passkey-delete-confirm form { display: flex; flex-wrap: wrap; gap: 0.5rem; align-items: center; width: 100%; }
+.passkey-delete-confirm label { display: flex; gap: 0.5rem; align-items: center; }
+.passkey-delete-confirm input[type=password] { padding: 6px; border-radius: 4px; border: 1px solid #888; }
 .token-box {
   white-space: pre-wrap;
   word-break: break-all;

--- a/src/gamatrix/static/templates/modern/style.css
+++ b/src/gamatrix/static/templates/modern/style.css
@@ -210,6 +210,10 @@ table.results tr.subthreshold td { color: var(--warning); }
   border-bottom: 1px solid var(--border);
 }
 .passkey-list li .muted, .token-list li .muted { flex: 1; }
+.passkey-delete-confirm { align-items: flex-start !important; flex-direction: column; }
+.passkey-delete-confirm form { display: flex; flex-wrap: wrap; gap: .5rem; align-items: center; width: 100%; }
+.passkey-delete-confirm label { display: flex; gap: .5rem; align-items: center; }
+.passkey-delete-confirm input[type=password] { padding: 6px; border-radius: 4px; border: 1px solid var(--border); }
 .token-box {
   white-space: pre-wrap;
   word-break: break-all;

--- a/src/gamatrix/templates/default/passkeys.html.jinja
+++ b/src/gamatrix/templates/default/passkeys.html.jinja
@@ -26,24 +26,7 @@
 
 <div class="card wide">
     <h3>Registered passkeys</h3>
-    {% if passkeys %}
-    <ul class="passkey-list">
-        {% for passkey in passkeys %}
-        <li>
-            <strong>{{ passkey.friendly_name }}</strong>
-            <span class="muted">
-                {% if passkey.backup_eligible %}sync-capable{% else %}device-bound{% endif %}
-                {% if passkey.backed_up %}, backed up{% endif %}
-                {% if passkey.created_at %} - added {{ passkey.created_at[:10] }}{% endif %}
-            </span>
-            <button type="button" class="secondary delete-passkey"
-                    data-credential-id="{{ passkey.credential_id }}">Delete</button>
-        </li>
-        {% endfor %}
-    </ul>
-    {% else %}
-    <p class="muted">No passkeys registered.</p>
-    {% endif %}
+    {% include "passkeys_manage_list.html.jinja" %}
 </div>
 <script src="/static/passkeys.js"></script>
 <script>window.gamatrixPasskeys.enableManagement();</script>

--- a/src/gamatrix/templates/modern/passkeys.html.jinja
+++ b/src/gamatrix/templates/modern/passkeys.html.jinja
@@ -26,24 +26,7 @@
 
 <div class="card wide">
     <h3>Registered passkeys</h3>
-    {% if passkeys %}
-    <ul class="passkey-list">
-        {% for passkey in passkeys %}
-        <li>
-            <strong>{{ passkey.friendly_name }}</strong>
-            <span class="muted">
-                {% if passkey.backup_eligible %}sync-capable{% else %}device-bound{% endif %}
-                {% if passkey.backed_up %}, backed up{% endif %}
-                {% if passkey.created_at %} - added {{ passkey.created_at[:10] }}{% endif %}
-            </span>
-            <button type="button" class="secondary delete-passkey"
-                    data-credential-id="{{ passkey.credential_id }}">Delete</button>
-        </li>
-        {% endfor %}
-    </ul>
-    {% else %}
-    <p class="muted">No passkeys registered.</p>
-    {% endif %}
+    {% include "passkeys_manage_list.html.jinja" %}
 </div>
 <script src="/static/passkeys.js"></script>
 <script>window.gamatrixPasskeys.enableManagement();</script>

--- a/src/gamatrix/templates/passkey_delete_form.html.jinja
+++ b/src/gamatrix/templates/passkey_delete_form.html.jinja
@@ -1,0 +1,16 @@
+<li class="passkey-delete-confirm">
+    <strong>Delete {{ passkey.friendly_name }}?</strong>
+    <form hx-post="/auth/passkeys/{{ passkey.credential_id }}/delete"
+          hx-target="closest li" hx-swap="outerHTML">
+        <label>
+            Current password
+            <input type="password" name="password" required
+                   autocomplete="current-password" autofocus>
+        </label>
+        <button type="submit">Confirm delete</button>
+        <button type="button" class="secondary"
+                hx-get="/auth/passkeys/manage/list"
+                hx-target="#passkey-list" hx-swap="outerHTML">Cancel</button>
+        {% if error %}<span class="error">{{ error }}</span>{% endif %}
+    </form>
+</li>

--- a/src/gamatrix/templates/passkeys_manage_list.html.jinja
+++ b/src/gamatrix/templates/passkeys_manage_list.html.jinja
@@ -1,0 +1,21 @@
+<div id="passkey-list">
+    {% if passkeys %}
+    <ul class="passkey-list">
+        {% for passkey in passkeys %}
+        <li>
+            <strong>{{ passkey.friendly_name }}</strong>
+            <span class="muted">
+                {% if passkey.backup_eligible %}sync-capable{% else %}device-bound{% endif %}
+                {% if passkey.backed_up %}, backed up{% endif %}
+                {% if passkey.created_at %} - added {{ passkey.created_at[:10] }}{% endif %}
+            </span>
+            <button type="button" class="secondary"
+                    hx-get="/auth/passkeys/{{ passkey.credential_id }}/delete"
+                    hx-target="closest li" hx-swap="outerHTML">Delete</button>
+        </li>
+        {% endfor %}
+    </ul>
+    {% else %}
+    <p class="muted">No passkeys registered.</p>
+    {% endif %}
+</div>

--- a/src/gamatrix/templating.py
+++ b/src/gamatrix/templating.py
@@ -22,6 +22,8 @@ AUTHENTICATED_TEMPLATE_NAMES = (
     "job_status.html.jinja",
     "passkeys.html.jinja",
     "passkeys_list.html.jinja",
+    "passkey_delete_form.html.jinja",
+    "passkeys_manage_list.html.jinja",
     "preferences.html.jinja",
     "tokens.html.jinja",
     "tokens_list.html.jinja",

--- a/src/gamatrix/templating.py
+++ b/src/gamatrix/templating.py
@@ -42,9 +42,18 @@ _configure(templates)
 
 
 def build_authenticated_templates(template_name: str) -> Jinja2Templates:
-    """Build an environment for a validated deployment-selected UX template."""
+    """Build an environment for a validated deployment-selected UX template.
+
+    The mode directory is searched first so a mode can override any template,
+    with the shared top-level templates directory as a fallback so mode pages
+    can ``{% include %}`` shared partials (e.g. ``passkeys_manage_list``).
+    """
     template_name = canonicalize_ux_template_name(template_name)
-    return _configure(Jinja2Templates(directory=str(TEMPLATES_DIR / template_name)))
+    return _configure(
+        Jinja2Templates(
+            directory=[str(TEMPLATES_DIR / template_name), str(TEMPLATES_DIR)]
+        )
+    )
 
 
 def configure_authenticated_templates(template_name: str) -> Jinja2Templates:

--- a/tests/test_passkeys.py
+++ b/tests/test_passkeys.py
@@ -222,7 +222,7 @@ def test_expired_challenge_and_unknown_credential_are_rejected(repo):
         assert response.status_code == 400
 
 
-def test_listing_hides_key_material_and_deletion_requires_password(repo):
+def test_listing_hides_key_material(repo):
     user = _user(repo)
     handle = repo.ensure_webauthn_user_id(user["email"], "opaque-handle")
     repo.put_passkey(
@@ -245,20 +245,6 @@ def test_listing_hides_key_material_and_deletion_requires_password(repo):
         assert "Current password" not in listed.text
         assert "public_key" not in listed.text
         assert "secret-public-key" not in listed.text
-
-        assert (
-            client.request(
-                "DELETE", "/auth/passkeys/credential", json={"password": "wrong"}
-            ).status_code
-            == 403
-        )
-        assert (
-            client.request(
-                "DELETE", "/auth/passkeys/credential", json={"password": "password"}
-            ).status_code
-            == 200
-        )
-        assert repo.get_passkey("credential") is None
 
 
 def test_inline_passkey_deletion_uses_password_field_and_refreshes_list(repo):
@@ -325,9 +311,7 @@ def test_delete_passkey_returns_explicit_404_without_registered_handle(repo):
     _user(repo)
     for client in _client(repo):
         _login(client)
-        response = client.request(
-            "DELETE", "/auth/passkeys/missing", json={"password": "password"}
-        )
+        response = client.get("/auth/passkeys/missing/delete")
         assert response.status_code == 404
         assert (
             response.json()["detail"] == "No passkeys are registered for this account."
@@ -339,9 +323,7 @@ def test_delete_passkey_returns_explicit_404_for_missing_credential(repo):
     repo.ensure_webauthn_user_id(user["email"], "opaque-handle")
     for client in _client(repo):
         _login(client)
-        response = client.request(
-            "DELETE", "/auth/passkeys/missing", json={"password": "password"}
-        )
+        response = client.get("/auth/passkeys/missing/delete")
         assert response.status_code == 404
         assert response.json()["detail"] == "Passkey not found for this account."
 

--- a/tests/test_passkeys.py
+++ b/tests/test_passkeys.py
@@ -54,7 +54,17 @@ def test_login_page_offers_explicit_and_conditional_passkeys(repo):
 
 
 def test_passkey_management_page_prefills_name_and_explains_password(repo):
-    _user(repo)
+    user = _user(repo)
+    handle = repo.ensure_webauthn_user_id(user["email"], "opaque-handle")
+    repo.put_passkey(
+        {
+            "credential_id": "credential",
+            "user_handle": handle,
+            "email": user["email"],
+            "sign_count": 0,
+            "friendly_name": "Laptop",
+        }
+    )
     for client in _client(repo):
         _login(client)
         response = client.get("/auth/passkeys")
@@ -64,6 +74,8 @@ def test_passkey_management_page_prefills_name_and_explains_password(repo):
             "Required to verify your identity before adding a passkey" in response.text
         )
         assert "Waiting for passkey creation to complete..." in response.text
+        assert 'hx-get="/auth/passkeys/credential/delete"' in response.text
+        assert "window.prompt" not in client.get("/static/passkeys.js").text
 
 
 def test_preferences_page_moves_manage_passkeys_into_page_body(repo):
@@ -247,6 +259,66 @@ def test_listing_hides_key_material_and_deletion_requires_password(repo):
             == 200
         )
         assert repo.get_passkey("credential") is None
+
+
+def test_inline_passkey_deletion_uses_password_field_and_refreshes_list(repo):
+    user = _user(repo)
+    handle = repo.ensure_webauthn_user_id(user["email"], "opaque-handle")
+    repo.put_passkey(
+        {
+            "credential_id": "credential",
+            "public_key": "secret-public-key",
+            "user_handle": handle,
+            "email": user["email"],
+            "sign_count": 0,
+            "friendly_name": "Laptop",
+        }
+    )
+    for client in _client(repo):
+        _login(client)
+
+        confirmation = client.get("/auth/passkeys/credential/delete")
+        assert confirmation.status_code == 200
+        assert "Delete Laptop?" in confirmation.text
+        assert 'type="password"' in confirmation.text
+        assert 'autocomplete="current-password"' in confirmation.text
+        assert "secret-public-key" not in confirmation.text
+
+        denied = client.post(
+            "/auth/passkeys/credential/delete", data={"password": "wrong"}
+        )
+        assert denied.status_code == 200
+        assert "Wrong password." in denied.text
+        assert 'value="wrong"' not in denied.text
+        assert repo.get_passkey("credential") is not None
+
+        deleted = client.post(
+            "/auth/passkeys/credential/delete", data={"password": "password"}
+        )
+        assert deleted.status_code == 200
+        assert deleted.headers["hx-retarget"] == "#passkey-list"
+        assert "Laptop" not in deleted.text
+        assert "No passkeys registered." in deleted.text
+        assert repo.get_passkey("credential") is None
+
+
+def test_inline_passkey_deletion_does_not_expose_another_accounts_passkey(repo):
+    user = _user(repo)
+    repo.ensure_webauthn_user_id(user["email"], "own-handle")
+    repo.put_passkey(
+        {
+            "credential_id": "other-credential",
+            "user_handle": "other-handle",
+            "email": "other@example.com",
+            "sign_count": 0,
+            "friendly_name": "Other laptop",
+        }
+    )
+    for client in _client(repo):
+        _login(client)
+        confirmation = client.get("/auth/passkeys/other-credential/delete")
+        assert confirmation.status_code == 404
+        assert "Other laptop" not in confirmation.text
 
 
 def test_delete_passkey_returns_explicit_404_without_registered_handle(repo):

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -78,6 +78,14 @@ def test_each_stylesheet_defines_every_required_mode_and_stays_small():
             assert f'data-mode="{mode}"' in css
 
 
+def test_authenticated_stylesheets_style_passkey_delete_confirmation():
+    for ux_template in UX_TEMPLATES:
+        css = Path(STATIC_TEMPLATES_DIR / ux_template / "style.css").read_text()
+        assert ".passkey-delete-confirm" in css
+        assert ".passkey-delete-confirm form" in css
+        assert ".passkey-delete-confirm input[type=password]" in css
+
+
 def test_default_preferences_template_includes_apply_preview_controls():
     environment = build_authenticated_templates("default")
     html = environment.env.get_template("preferences.html.jinja").render(


### PR DESCRIPTION
## What

Fix for #163 - removes the plain-text dialog for entering your password when deleting a passkey.

## How

Replaces the plain-text dialog popup that requests your current password prior to allowing you to delete your passkey.

- Remove plain-text popup requesting users password from passkey revokation flow
  - Replace the use of window.prompt in revokation flow
  - Co-authored by codex (GPT 5.5)

- Update to handle multiple templates
  - Give the authenticated template env a fallback search path to the shared
    top-level templates dir (mode dir still wins for overrides), and convert
    default/passkeys.html.jinja to include the shared list partial like modern.
  - Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

- Remove orphaned DELETE /passkeys/{credential_id} route
  - `DELETE /auth/passkeys/{credential_id}` endpoint (and its
    DeletePasskeyRequest model) was only ever called by the window.prompt
    handler in passkeys.js
  - Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

- Fix up tests
  - the wrong/right-password deletion assertions are already covered by
      test_inline_passkey_deletion_uses_password_field_and_refreshes_list, so
      trim them from the listing test (renamed test_listing_hides_key_material)
  - repoint the two explicit-404 tests at GET /passkeys/{id}/delete
  - Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

## Checklist

- [ ] PR checks pass
- [x] Tests added/updated for the change
- [x] Version label applied if this is more than a patch (see below)
