### PR TITLE
Show confirmed single-player games as 1 player

### DIFF
--- a/src/gamatrix/games/service.py
+++ b/src/gamatrix/games/service.py
@@ -15,6 +15,7 @@ from typing import Literal, Protocol
 from gamatrix.config import Settings, get_settings
 from gamatrix.constants import (
     ENRICHMENT_PENDING,
+    IGDB_GAME_MODE,
     IGDB_MULTIPLAYER_GAME_MODES,
     PLATFORMS,
 )
@@ -152,7 +153,7 @@ def _build_game(rk: str, slot: dict, meta: dict, overrides: dict) -> ComparisonI
         platforms=[slot["platform"]],
         owners=sorted(slot["owners"]),
         installed=sorted(slot["installed"]),
-        max_players=meta.get("max_players", 0),
+        max_players=_display_max_players(meta),
         multiplayer=meta.get("multiplayer", False),
         rating=meta.get("rating", 0),
         rating_count=meta.get("rating_count", 0),
@@ -173,6 +174,23 @@ def _build_game(rk: str, slot: dict, meta: dict, overrides: dict) -> ComparisonI
         if override.get("url"):
             game.url = override["url"]
     return game
+
+
+def _display_max_players(meta: dict) -> int:
+    """Player count to show for a game.
+
+    IGDB gives confirmed single-player games no max-player figure, which would
+    otherwise render as an empty Players cell. When a game is known single-player
+    (IGDB lists the single-player mode and nothing multiplayer), surface that as
+    1 player instead of a blank. Games with an unknown mode set stay at 0 so we
+    don't claim a count IGDB never confirmed.
+    """
+    max_players = meta.get("max_players", 0)
+    if max_players or meta.get("multiplayer", False):
+        return max_players
+    if IGDB_GAME_MODE["singleplayer"] in meta.get("game_modes", []):
+        return 1
+    return max_players
 
 
 def _multiplayer(max_players: int, game_modes: list[int]) -> bool:

--- a/tests/test_games.py
+++ b/tests/test_games.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from gamatrix.constants import JOB_RUNNING
+from gamatrix.constants import IGDB_GAME_MODE, JOB_RUNNING
 from gamatrix.games.service import (
     ComparisonQuery,
     SortSpec,
@@ -113,6 +113,46 @@ def test_metadata_override_applied(populated):
     coop = next(g for g in result.items if g.slug == "coopgame")
     assert coop.max_players == 2
     assert coop.comment == "Use Hamachi"
+
+
+def test_confirmed_single_player_populates_one_player(repo):
+    """A game IGDB confirms is single-player (single-player mode, no count)
+    shows 1 player; a game with no known modes stays blank (0)."""
+    repo.put_user({"email": "a@x.com", "username": "A", "user_id": "1"})
+
+    def game(rk, slug, game_modes):
+        repo.put_game(
+            {
+                "release_key": rk,
+                "title": slug,
+                "slug": slug,
+                "igdb_key": rk,
+                "platform": "steam",
+                "multiplayer": False,
+                "max_players": 0,
+                "game_modes": game_modes,
+                "enrichment_status": "done",
+                "enriched_at": now_iso(),
+            }
+        )
+
+    game("steam_50", "solo", [IGDB_GAME_MODE["singleplayer"]])
+    game("steam_51", "mystery", [])
+    repo.replace_user_library(
+        "1",
+        [
+            {"release_key": "steam_50", "platform": "steam", "installed": False},
+            {"release_key": "steam_51", "platform": "steam", "installed": False},
+        ],
+    )
+
+    result = compare(
+        repo,
+        ComparisonQuery(selected_user_ids=["1"], include_single_player=True),
+    )
+    by_slug = {g.slug: g for g in result.items}
+    assert by_slug["solo"].max_players == 1
+    assert by_slug["mystery"].max_players == 0
 
 
 def test_merge_cross_platform_duplicates(repo):


### PR DESCRIPTION
## Summary

IGDB returns no max-player figure for games it confirms are single-player, so those games rendered with a **blank Players column**. This auto-populates them with **Players = 1**.

The fill happens in the comparison service (`_build_game`), gated on the game being **confirmed single-player** — IGDB lists the single-player game mode and nothing multiplayer (`multiplayer` is false). Games with an **unknown** mode set stay at `0` (blank) so we never assert a count IGDB didn't confirm.

## Why the service layer

- Covers **every already-enriched game** and the `/api/games` response, not just newly-enriched ones (the IGDB client already sets `1` for the narrow exact-`[singleplayer]` case at enrichment time; this generalizes it at read time without a re-enrich).
- Sorting by Players (`SORT_KEYS["players"]`) and the subthreshold row styling both read this value, so they stay consistent.
- Explicit `metadata_overrides` still win (applied after the base value).

## Testing

- New `test_confirmed_single_player_populates_one_player`: a single-player-mode game shows `1`; an unknown-mode game stays `0`.
- `just check` (black, flake8, mypy, pytest): **162 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)