### PR TITLE
Chunk enrichment jobs so full refreshes don't time out

### DIFF
--- a/infrastructure/cdk/gamatrix_stack.py
+++ b/infrastructure/cdk/gamatrix_stack.py
@@ -45,6 +45,11 @@ from config import DeployConfig
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 TABLE_PREFIX = "gamatrix"
 DEFAULT_EMAIL_FROM = "noreply@example.com"
+# Max enricher invocations SQS runs in parallel. The same value is handed to the
+# enricher (ENRICHER_MAX_CONCURRENCY) so it scales its IGDB call delay and the
+# workers share, rather than each consume, IGDB's 4 req/sec budget. The SQS event
+# source enforces a floor of 2, so 2 is the lowest safe value.
+ENRICHER_MAX_CONCURRENCY = 2
 
 
 def _project_version() -> str:
@@ -168,7 +173,12 @@ class GamatrixStack(Stack):
             "EnricherFn",
             "lambda-enricher",
             "handler.handler",
-            env=common_env,
+            # The enricher scales its IGDB call delay by this so parallel
+            # invocations share the rate-limit budget (see enricher.run_job).
+            env={
+                **common_env,
+                "ENRICHER_MAX_CONCURRENCY": str(ENRICHER_MAX_CONCURRENCY),
+            },
             timeout=Duration.minutes(15),
         )
         parser_fn = self._lambda(
@@ -195,12 +205,15 @@ class GamatrixStack(Stack):
 
         # Triggers.
         # A job fans out to one message per chunk (see gamatrix.jobs). Cap
-        # concurrency so a full-library refresh doesn't run many chunks at once,
-        # each with its own IGDB rate limiter, and collectively trip IGDB's
-        # global throttle. Chunking already keeps each invocation under the
-        # 15-min timeout, so bounded parallelism costs wall-clock, not success.
+        # concurrency so a full-library refresh doesn't run unbounded chunks at
+        # once; the enricher scales its IGDB delay by the same number so the
+        # workers share the rate-limit budget rather than each consume it.
+        # Chunking already keeps each invocation under the 15-min timeout, so
+        # bounded parallelism costs wall-clock, not success.
         enricher_fn.add_event_source(
-            sources.SqsEventSource(queue, batch_size=1, max_concurrency=2)
+            sources.SqsEventSource(
+                queue, batch_size=1, max_concurrency=ENRICHER_MAX_CONCURRENCY
+            )
         )
         upload_bucket.add_event_notification(
             s3.EventType.OBJECT_CREATED,

--- a/infrastructure/cdk/gamatrix_stack.py
+++ b/infrastructure/cdk/gamatrix_stack.py
@@ -194,7 +194,14 @@ class GamatrixStack(Stack):
         web_fn.add_to_role_policy(self._ses_send_policy())
 
         # Triggers.
-        enricher_fn.add_event_source(sources.SqsEventSource(queue, batch_size=1))
+        # A job fans out to one message per chunk (see gamatrix.jobs). Cap
+        # concurrency so a full-library refresh doesn't run many chunks at once,
+        # each with its own IGDB rate limiter, and collectively trip IGDB's
+        # global throttle. Chunking already keeps each invocation under the
+        # 15-min timeout, so bounded parallelism costs wall-clock, not success.
+        enricher_fn.add_event_source(
+            sources.SqsEventSource(queue, batch_size=1, max_concurrency=2)
+        )
         upload_bucket.add_event_notification(
             s3.EventType.OBJECT_CREATED,
             s3n.LambdaDestination(parser_fn),

--- a/lambdas/igdb_enricher/handler.py
+++ b/lambdas/igdb_enricher/handler.py
@@ -1,6 +1,9 @@
-"""SQS-triggered Lambda: run IGDB enrichment jobs.
+"""SQS-triggered Lambda: run one chunk of an IGDB enrichment job.
 
-Each SQS message carries a job_id produced by gamatrix.jobs.create_enrichment_job.
+Each SQS message carries a `job_id` and `chunk_index` produced by
+gamatrix.jobs.create_enrichment_job. The chunk_index selects this invocation's
+slice of the job's release keys so no single run has to enrich the whole library
+within the Lambda timeout.
 """
 
 from __future__ import annotations
@@ -21,6 +24,7 @@ def handler(event, context):
     for record in event.get("Records", []):
         body = json.loads(record["body"])
         job_id = body["job_id"]
-        log.info("Processing enrichment job %s", job_id)
-        asyncio.run(run_job(job_id, repo))
+        chunk_index = body.get("chunk_index")
+        log.info("Processing enrichment job %s chunk %s", job_id, chunk_index)
+        asyncio.run(run_job(job_id, repo, chunk_index=chunk_index))
     return {"statusCode": 200}

--- a/scripts/local_worker.py
+++ b/scripts/local_worker.py
@@ -33,7 +33,14 @@ def main() -> None:
             pending = []
         for job in pending:
             log.info("Running job %s (%d games)", job["job_id"], job.get("total", 0))
-            asyncio.run(run_job(job["job_id"], repo))
+            try:
+                # No chunk_index: locally there's no SQS fan-out, so the worker
+                # runs the whole job in one pass.
+                asyncio.run(run_job(job["job_id"], repo))
+            except Exception:
+                # One bad job shouldn't kill the poll loop; the stale reaper will
+                # mark it dead so it stops blocking new enrichment.
+                log.exception("Enrichment job %s failed", job["job_id"])
         time.sleep(POLL_SECONDS)
 
 

--- a/src/gamatrix/config.py
+++ b/src/gamatrix/config.py
@@ -74,6 +74,12 @@ class Settings(BaseSettings):
     igdb_stale_days: int = 30
     ux_template: str = DEFAULT_UX_TEMPLATE
 
+    # Max number of enricher invocations that run at once (mirrors the SQS event
+    # source's max_concurrency in AWS). The enricher scales its IGDB call delay by
+    # this so parallel workers share, rather than each consume, the 4 req/sec
+    # budget. Defaults to 1: locally the worker runs a single job at a time.
+    enricher_max_concurrency: int = 1
+
     # How long the Repository serves the comparison read-model (users, games,
     # libraries, metadata overrides) from its in-process cache before re-reading
     # from DynamoDB. Lets repeated filter changes reuse one set of reads. Writes

--- a/src/gamatrix/constants.py
+++ b/src/gamatrix/constants.py
@@ -82,3 +82,9 @@ JOB_FAILED = "failed"
 # status). Past this it stops driving the UI. Kept above the enricher's 15-min
 # Lambda timeout so a slow-but-live job isn't reaped mid-run.
 JOB_TIMEOUT_MINUTES = 20
+
+# A job's release keys are split into chunks of this size, one SQS message each,
+# so no single enricher invocation has to enrich the whole library within the
+# 15-min Lambda timeout. IGDB rate limiting caps throughput at ~1 game/sec, so a
+# chunk this size finishes with comfortable margin while keeping messages small.
+ENRICHMENT_CHUNK_SIZE = 200

--- a/src/gamatrix/constants.py
+++ b/src/gamatrix/constants.py
@@ -50,7 +50,10 @@ IGDB_MAX_PLAYER_KEYS = [
     "onlinemax",
 ]
 
-# The IGDB API has a rate limit of 4 requests/sec.
+# The IGDB API has a rate limit of 4 requests/sec. This delay is per client
+# (per enricher process); with several enricher invocations running in parallel
+# the effective delay is scaled up by the concurrency so their combined request
+# rate still fits the shared budget (see ENRICHER_MAX_CONCURRENCY).
 IGDB_API_CALL_DELAY = 0.25
 
 # Order matters; when deduping, the release key retained is the first one in

--- a/src/gamatrix/games/routes.py
+++ b/src/gamatrix/games/routes.py
@@ -149,12 +149,12 @@ def refresh_all(
     repo: Repository = Depends(get_repo),
 ):
     """Re-enrich every game from scratch."""
-    release_keys = [g["release_key"] for g in repo.scan_all_games()]
-    # Mark them pending so the staleness check and UI reflect the refresh.
-    for rk in release_keys:
-        game = repo.get_game(rk)
-        if game:
-            repo.put_game({**game, "enrichment_status": ENRICHMENT_PENDING})
+    games = repo.scan_all_games()
+    # Flip every game to pending (batched) so the enricher won't skip it and the
+    # staleness check / UI reflect the refresh. The scan already returned each
+    # full record, so re-fetching per row would just be wasted round-trips.
+    repo.mark_games_pending(games)
+    release_keys = [g["release_key"] for g in games]
     job_id = create_enrichment_job(repo, get_queue(), release_keys)
     return authenticated_fragment(
         request,

--- a/src/gamatrix/igdb/client.py
+++ b/src/gamatrix/igdb/client.py
@@ -75,12 +75,17 @@ class IGDBClient:
     TOKEN_URL = "https://id.twitch.tv/oauth2/token"
     API_BASE = "https://api.igdb.com/v4"
 
-    def __init__(self, client_id: str, client_secret: str):
+    def __init__(
+        self,
+        client_id: str,
+        client_secret: str,
+        call_delay: float = IGDB_API_CALL_DELAY,
+    ):
         self.client_id = client_id
         self.client_secret = client_secret
         self.access_token: str | None = None
         self._http = httpx.AsyncClient(timeout=30.0)
-        self._limiter = _RateLimiter(IGDB_API_CALL_DELAY)
+        self._limiter = _RateLimiter(call_delay)
 
     async def aclose(self) -> None:
         await self._http.aclose()

--- a/src/gamatrix/igdb/enricher.py
+++ b/src/gamatrix/igdb/enricher.py
@@ -1,7 +1,10 @@
 """Run an enrichment job: look up IGDB metadata and write it to DynamoDB.
 
 Invoked by the SQS-triggered enricher Lambda in AWS and by the local_worker in
-development. Both call run_job(job_id) after constructing a Repository.
+development. A job's release keys are split into fixed-size chunks, one SQS
+message each, so no single invocation has to enrich the whole library within the
+Lambda 15-min timeout. The Lambda passes the message's `chunk_index`; the local
+worker passes none and runs the whole job in one pass.
 """
 
 from __future__ import annotations
@@ -10,11 +13,11 @@ import logging
 
 from gamatrix.config import Settings, get_settings, resolve_igdb_credentials
 from gamatrix.constants import (
+    ENRICHMENT_CHUNK_SIZE,
     ENRICHMENT_DONE,
     ENRICHMENT_NOT_FOUND,
     ENRICHMENT_PENDING,
     JOB_COMPLETED,
-    JOB_FAILED,
     JOB_RUNNING,
 )
 from gamatrix.helpers import now_iso
@@ -25,7 +28,10 @@ log = logging.getLogger(__name__)
 
 
 async def run_job(
-    job_id: str, repo: Repository, settings: Settings | None = None
+    job_id: str,
+    repo: Repository,
+    settings: Settings | None = None,
+    chunk_index: int | None = None,
 ) -> None:
     settings = settings or get_settings()
     job = repo.get_job(job_id)
@@ -35,12 +41,22 @@ async def run_job(
 
     repo.update_job(job_id, {"status": JOB_RUNNING, "updated_at": now_iso()})
     release_keys: list[str] = job.get("release_keys", [])
+    total: int = job.get("total", len(release_keys))
+
+    # A chunk_index slices this invocation's share of the job; the local worker
+    # passes none and takes the whole job (there is no Lambda timeout locally).
+    if chunk_index is None:
+        keys, chunk_id = release_keys, "all"
+    else:
+        start = chunk_index * ENRICHMENT_CHUNK_SIZE
+        keys = release_keys[start : start + ENRICHMENT_CHUNK_SIZE]
+        chunk_id = str(chunk_index)
 
     # Group release keys by the IGDB key so games shared across platforms
     # (e.g. a Steam and a GOG copy) only cost one set of API calls.
-    games = repo.batch_get_games(release_keys)
+    games = repo.batch_get_games(keys)
     by_igdb_key: dict[str, list[str]] = {}
-    for rk in release_keys:
+    for rk in keys:
         game = games.get(rk)
         if game is None:
             continue
@@ -48,32 +64,40 @@ async def run_job(
             continue
         by_igdb_key.setdefault(game["igdb_key"], []).append(rk)
 
-    client_id, client_secret = resolve_igdb_credentials(settings)
-    completed = 0
-    try:
+    # Keys needing no work (missing from the table, or already enriched by an
+    # earlier delivery) still count as processed so the bar can reach 100%.
+    to_enrich = sum(len(rks) for rks in by_igdb_key.values())
+    completed = len(keys) - to_enrich
+    progress = repo.set_chunk_progress(job_id, chunk_id, completed)
+
+    if by_igdb_key:
+        client_id, client_secret = resolve_igdb_credentials(settings)
         async with IGDBClient(client_id, client_secret) as client:
             for igdb_key, rks in by_igdb_key.items():
                 # Use any sharing release key's title for matching.
                 title = games[rks[0]].get("title", "")
                 try:
                     meta = await client.fetch_metadata(igdb_key, title)
-                except Exception:  # one game's failure shouldn't sink the job
+                except Exception:  # one game's failure shouldn't sink the chunk
                     log.exception("Failed to enrich %s (%s)", igdb_key, title)
                     meta = GameMetadata()
                 for rk in rks:
                     _write_metadata(repo, games[rk], meta)
                     completed += 1
-                    # Absolute, not incremental: a redelivered or concurrent
-                    # run converges here instead of pushing the count past
-                    # `total` (see #131).
-                    repo.set_job_progress(job_id, completed)
-    except Exception:
-        log.exception("Enrichment job %s failed", job_id)
-        repo.update_job(job_id, {"status": JOB_FAILED, "completed_at": now_iso()})
-        return
+                # Absolute per-chunk progress: a redelivered or concurrent run
+                # of this chunk converges here instead of pushing the count past
+                # `total` (see #131).
+                progress = repo.set_chunk_progress(job_id, chunk_id, completed)
 
-    repo.update_job(job_id, {"status": JOB_COMPLETED, "completed_at": now_iso()})
-    log.info("Enrichment job %s completed (%d games)", job_id, len(release_keys))
+    # The chunk that accounts for the final outstanding keys closes the job.
+    # Idempotent: re-completing an already-completed job is harmless.
+    if sum(progress.values()) >= total:
+        repo.update_job(job_id, {"status": JOB_COMPLETED, "completed_at": now_iso()})
+        log.info("Enrichment job %s completed (%d games)", job_id, total)
+    else:
+        log.info(
+            "Enrichment job %s chunk %s done (%d keys)", job_id, chunk_id, len(keys)
+        )
 
 
 def _write_metadata(repo: Repository, game: dict, meta: GameMetadata) -> None:

--- a/src/gamatrix/igdb/enricher.py
+++ b/src/gamatrix/igdb/enricher.py
@@ -17,6 +17,7 @@ from gamatrix.constants import (
     ENRICHMENT_DONE,
     ENRICHMENT_NOT_FOUND,
     ENRICHMENT_PENDING,
+    IGDB_API_CALL_DELAY,
     JOB_COMPLETED,
     JOB_RUNNING,
 )
@@ -72,7 +73,11 @@ async def run_job(
 
     if by_igdb_key:
         client_id, client_secret = resolve_igdb_credentials(settings)
-        async with IGDBClient(client_id, client_secret) as client:
+        # Parallel enricher invocations each pace themselves, so scale the delay
+        # by the concurrency: N workers at (N x base) delay share the 4 req/sec
+        # budget instead of each consuming all of it and tripping IGDB's throttle.
+        call_delay = IGDB_API_CALL_DELAY * max(settings.enricher_max_concurrency, 1)
+        async with IGDBClient(client_id, client_secret, call_delay) as client:
             for igdb_key, rks in by_igdb_key.items():
                 # Use any sharing release key's title for matching.
                 title = games[rks[0]].get("title", "")

--- a/src/gamatrix/jobs.py
+++ b/src/gamatrix/jobs.py
@@ -8,6 +8,7 @@ from datetime import datetime, timedelta, timezone
 from typing import NotRequired, TypedDict
 
 from gamatrix.constants import (
+    ENRICHMENT_CHUNK_SIZE,
     JOB_PENDING,
     JOB_RUNNING,
     JOB_TIMEOUT_MINUTES,
@@ -34,6 +35,10 @@ class JobRecord(TypedDict):
     release_keys: list[str]
     total: int
     completed_count: int
+    # Absolute progress per chunk (`{chunk_id: count}`); `completed_count` is
+    # derived from its sum. Parallel chunks update distinct keys so they don't
+    # clobber each other. Empty until the first chunk records progress.
+    chunk_progress: NotRequired[dict[str, int]]
     updated_at: NotRequired[str]
 
 
@@ -79,8 +84,21 @@ def create_enrichment_job(
         "release_keys": release_keys,
         "total": len(release_keys),
         "completed_count": 0,
+        "chunk_progress": {},
     }
     repo.put_job(job)
-    queue.enqueue(job_id)
-    log.info("Created enrichment job %s for %d games", job_id, len(release_keys))
+    # One message per chunk so each enricher invocation processes only its slice
+    # and finishes well inside the Lambda timeout; SQS fans the chunks out across
+    # concurrent invocations. Locally the queue is a no-op and the worker runs
+    # the whole job in a single pass.
+    chunk_count = 0
+    for start in range(0, len(release_keys), ENRICHMENT_CHUNK_SIZE):
+        queue.enqueue(job_id, start // ENRICHMENT_CHUNK_SIZE)
+        chunk_count += 1
+    log.info(
+        "Created enrichment job %s for %d games in %d chunk(s)",
+        job_id,
+        len(release_keys),
+        chunk_count,
+    )
     return job_id

--- a/src/gamatrix/storage/dynamo.py
+++ b/src/gamatrix/storage/dynamo.py
@@ -15,6 +15,7 @@ import boto3
 from boto3.dynamodb.conditions import Key
 
 from gamatrix.config import Settings, get_settings
+from gamatrix.constants import ENRICHMENT_PENDING
 from gamatrix.helpers import now_iso
 
 if TYPE_CHECKING:
@@ -129,6 +130,19 @@ class Repository:
 
     def put_game(self, game: dict) -> None:
         self._table(self.settings.games_table).put_item(Item=_to_dynamo(game))
+        self._cache_invalidate("games_map")
+
+    def mark_games_pending(self, games: list[dict]) -> None:
+        """Flip a batch of games to `pending` so the enricher won't skip them
+        (it only touches unset/pending games, see #134). Batched because a
+        full-library refresh re-stamps thousands of rows and a per-row loop would
+        blow the web request timeout."""
+        table = self._table(self.settings.games_table)
+        with table.batch_writer() as batch:
+            for game in games:
+                batch.put_item(
+                    Item=_to_dynamo({**game, "enrichment_status": ENRICHMENT_PENDING})
+                )
         self._cache_invalidate("games_map")
 
     def scan_all_games(self) -> list[dict]:
@@ -292,7 +306,15 @@ class Repository:
     def get_job(self, job_id: str) -> JobRecord | None:
         resp = self._table(self.settings.jobs_table).get_item(Key={"job_id": job_id})
         item = resp.get("Item")
-        return _from_dynamo(item) if item else None
+        if item is None:
+            return None
+        job = _from_dynamo(item)
+        # `completed_count` is derived from the per-chunk progress map rather than
+        # stored, so parallel chunks never race on a shared counter.
+        progress = job.get("chunk_progress")
+        if progress:
+            job["completed_count"] = sum(progress.values())
+        return job
 
     def update_job(self, job_id: str, attrs: dict) -> None:
         names = {f"#{k}": k for k in attrs}
@@ -305,15 +327,30 @@ class Repository:
             ExpressionAttributeValues=values,
         )
 
-    def set_job_progress(self, job_id: str, completed_count: int) -> None:
-        """Record absolute progress. Idempotent across SQS redeliveries: a
-        retried or concurrently-running enricher converges on the same value
-        instead of inflating an atomic counter past `total` (see #131). Also
-        stamps `updated_at` so staleness is measured from the last progress,
-        not job creation."""
-        self.update_job(
-            job_id, {"completed_count": completed_count, "updated_at": now_iso()}
+    def set_chunk_progress(
+        self, job_id: str, chunk_id: str, count: int
+    ) -> dict[str, int]:
+        """Record absolute progress for one chunk and return the full per-chunk
+        progress map (post-write).
+
+        Absolute, not incremental: a redelivered or concurrent run of the same
+        chunk converges on the same value instead of inflating the count past
+        `total` (see #131). Each chunk writes its own map key, so parallel chunks
+        of one job update the same row without a read-modify-write race. Also
+        stamps `updated_at` so staleness is measured from the last progress, not
+        job creation."""
+        resp = self._table(self.settings.jobs_table).update_item(
+            Key={"job_id": job_id},
+            UpdateExpression="SET chunk_progress.#c = :v, #u = :u",
+            ExpressionAttributeNames={"#c": chunk_id, "#u": "updated_at"},
+            ExpressionAttributeValues={
+                ":v": _to_dynamo(count),
+                ":u": now_iso(),
+            },
+            ReturnValues="ALL_NEW",
         )
+        attrs = _from_dynamo(resp.get("Attributes", {}))
+        return attrs.get("chunk_progress", {})
 
     def list_pending_jobs(self) -> list[dict]:
         from gamatrix.constants import JOB_PENDING

--- a/src/gamatrix/storage/queue.py
+++ b/src/gamatrix/storage/queue.py
@@ -28,14 +28,17 @@ class EnrichmentQueue:
                 endpoint_url=self.settings.sqs_endpoint_url,
             )
 
-    def enqueue(self, job_id: str) -> None:
-        """Publish a job id. No-op when no queue is configured (local dev)."""
+    def enqueue(self, job_id: str, chunk_index: int) -> None:
+        """Publish one chunk of a job. The enricher reads `chunk_index` to slice
+        the job's release keys, so each invocation processes only its share.
+        No-op when no queue is configured (local dev); the local worker runs the
+        whole job instead."""
         if self._client is None or self.settings.enrichment_queue_url is None:
             log.info("No SQS queue configured; job %s left for local worker", job_id)
             return
         self._client.send_message(
             QueueUrl=self.settings.enrichment_queue_url,
-            MessageBody=json.dumps({"job_id": job_id}),
+            MessageBody=json.dumps({"job_id": job_id, "chunk_index": chunk_index}),
         )
 
 

--- a/tests/test_enricher_chunking.py
+++ b/tests/test_enricher_chunking.py
@@ -8,7 +8,14 @@ from __future__ import annotations
 
 import gamatrix.igdb.enricher as enricher
 import gamatrix.jobs as jobs
-from gamatrix.constants import ENRICHMENT_DONE, JOB_COMPLETED, JOB_RUNNING
+from gamatrix.constants import (
+    ENRICHMENT_DONE,
+    ENRICHMENT_PENDING,
+    IGDB_API_CALL_DELAY,
+    JOB_COMPLETED,
+    JOB_RUNNING,
+)
+from gamatrix.igdb.client import GameMetadata
 from gamatrix.igdb.enricher import run_job
 from gamatrix.jobs import create_enrichment_job
 
@@ -36,6 +43,33 @@ def _seed_done_games(repo, release_keys):
                 "enrichment_status": ENRICHMENT_DONE,
             }
         )
+
+
+class _FakeIGDBClient:
+    """Stand-in for IGDBClient that records the call_delay it was built with and
+    does no network I/O."""
+
+    last_call_delay: float | None = None
+
+    def __init__(self, client_id, client_secret, call_delay=IGDB_API_CALL_DELAY):
+        type(self).last_call_delay = call_delay
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def fetch_metadata(self, igdb_key, title):
+        return GameMetadata()
+
+
+def _stub_igdb(monkeypatch):
+    _FakeIGDBClient.last_call_delay = None
+    monkeypatch.setattr(enricher, "IGDBClient", _FakeIGDBClient)
+    monkeypatch.setattr(
+        enricher, "resolve_igdb_credentials", lambda settings: ("id", "secret")
+    )
 
 
 def test_create_enrichment_job_fans_out_one_message_per_chunk(repo, monkeypatch):
@@ -121,3 +155,43 @@ async def test_local_worker_path_runs_whole_job_in_one_pass(
     job = repo.get_job(job_id)
     assert job["status"] == JOB_COMPLETED
     assert job["completed_count"] == 5
+
+
+async def test_igdb_call_delay_scales_with_concurrency(repo, settings, monkeypatch):
+    # With N enricher invocations running in parallel, each must pace at N x the
+    # base delay so their combined request rate stays within IGDB's budget.
+    _stub_igdb(monkeypatch)
+    repo.put_game(
+        {
+            "release_key": "steam_1",
+            "title": "Pending Game",
+            "igdb_key": "steam_1",
+            "platform": "steam",
+            "enrichment_status": ENRICHMENT_PENDING,
+        }
+    )
+    job_id = create_enrichment_job(repo, _RecordingQueue(), ["steam_1"])
+
+    concurrent = settings.model_copy(update={"enricher_max_concurrency": 2})
+    await run_job(job_id, repo, settings=concurrent, chunk_index=0)
+
+    assert _FakeIGDBClient.last_call_delay == IGDB_API_CALL_DELAY * 2
+
+
+async def test_igdb_call_delay_defaults_to_full_budget(repo, settings, monkeypatch):
+    # A single worker (the local/default case) uses the full 4 req/sec budget.
+    _stub_igdb(monkeypatch)
+    repo.put_game(
+        {
+            "release_key": "steam_1",
+            "title": "Pending Game",
+            "igdb_key": "steam_1",
+            "platform": "steam",
+            "enrichment_status": ENRICHMENT_PENDING,
+        }
+    )
+    job_id = create_enrichment_job(repo, _RecordingQueue(), ["steam_1"])
+
+    await run_job(job_id, repo, settings=settings, chunk_index=0)
+
+    assert _FakeIGDBClient.last_call_delay == IGDB_API_CALL_DELAY

--- a/tests/test_enricher_chunking.py
+++ b/tests/test_enricher_chunking.py
@@ -1,0 +1,123 @@
+"""Enrichment jobs are split into fixed-size chunks, one SQS message each, so no
+single enricher invocation has to enrich the whole library within the Lambda
+15-min timeout. These tests cover the fan-out on creation and the per-chunk
+processing / completion / progress accounting on the enricher side.
+"""
+
+from __future__ import annotations
+
+import gamatrix.igdb.enricher as enricher
+import gamatrix.jobs as jobs
+from gamatrix.constants import ENRICHMENT_DONE, JOB_COMPLETED, JOB_RUNNING
+from gamatrix.igdb.enricher import run_job
+from gamatrix.jobs import create_enrichment_job
+
+
+class _RecordingQueue:
+    """Captures enqueue(job_id, chunk_index) calls instead of hitting SQS."""
+
+    def __init__(self):
+        self.messages: list[tuple[str, int]] = []
+
+    def enqueue(self, job_id: str, chunk_index: int) -> None:
+        self.messages.append((job_id, chunk_index))
+
+
+def _seed_done_games(repo, release_keys):
+    # Games already enriched: the enricher does no IGDB work for them (so these
+    # tests need no network), but they must still count toward progress.
+    for rk in release_keys:
+        repo.put_game(
+            {
+                "release_key": rk,
+                "title": rk,
+                "igdb_key": rk,
+                "platform": rk.split("_")[0],
+                "enrichment_status": ENRICHMENT_DONE,
+            }
+        )
+
+
+def test_create_enrichment_job_fans_out_one_message_per_chunk(repo, monkeypatch):
+    monkeypatch.setattr(jobs, "ENRICHMENT_CHUNK_SIZE", 2)
+    queue = _RecordingQueue()
+    keys = ["steam_1", "steam_2", "steam_3", "steam_4", "steam_5"]
+
+    job_id = create_enrichment_job(repo, queue, keys)
+
+    # 5 keys / chunk size 2 -> chunks 0, 1, 2.
+    assert [idx for _, idx in queue.messages] == [0, 1, 2]
+    assert all(jid == job_id for jid, _ in queue.messages)
+    job = repo.get_job(job_id)
+    assert job["total"] == 5
+    assert job["release_keys"] == keys
+
+
+def test_create_enrichment_job_dedupes_before_chunking(repo, monkeypatch):
+    monkeypatch.setattr(jobs, "ENRICHMENT_CHUNK_SIZE", 2)
+    queue = _RecordingQueue()
+
+    job_id = create_enrichment_job(repo, queue, ["steam_1", "steam_1", "steam_2"])
+
+    assert repo.get_job(job_id)["release_keys"] == ["steam_1", "steam_2"]
+    assert [idx for _, idx in queue.messages] == [0]
+
+
+async def test_chunk_completes_job_only_when_all_chunks_done(
+    repo, settings, monkeypatch
+):
+    monkeypatch.setattr(enricher, "ENRICHMENT_CHUNK_SIZE", 2)
+    monkeypatch.setattr(jobs, "ENRICHMENT_CHUNK_SIZE", 2)
+    keys = ["steam_1", "steam_2", "steam_3", "steam_4", "steam_5"]
+    _seed_done_games(repo, keys)
+    job_id = create_enrichment_job(repo, _RecordingQueue(), keys)
+
+    await run_job(job_id, repo, settings=settings, chunk_index=0)
+    job = repo.get_job(job_id)
+    assert job["status"] == JOB_RUNNING
+    assert job["completed_count"] == 2
+
+    await run_job(job_id, repo, settings=settings, chunk_index=1)
+    assert repo.get_job(job_id)["status"] == JOB_RUNNING
+
+    await run_job(job_id, repo, settings=settings, chunk_index=2)
+    job = repo.get_job(job_id)
+    assert job["status"] == JOB_COMPLETED
+    assert job["completed_count"] == 5
+    assert job["completed_at"]
+
+
+async def test_redelivered_chunk_does_not_inflate_progress(repo, settings, monkeypatch):
+    monkeypatch.setattr(enricher, "ENRICHMENT_CHUNK_SIZE", 2)
+    monkeypatch.setattr(jobs, "ENRICHMENT_CHUNK_SIZE", 2)
+    keys = ["steam_1", "steam_2", "steam_3"]
+    _seed_done_games(repo, keys)
+    job_id = create_enrichment_job(repo, _RecordingQueue(), keys)
+
+    await run_job(job_id, repo, settings=settings, chunk_index=0)
+    # SQS redelivers the same chunk: its slot is set absolutely, so the total
+    # can't climb past `total` (see #131).
+    await run_job(job_id, repo, settings=settings, chunk_index=0)
+    await run_job(job_id, repo, settings=settings, chunk_index=1)
+
+    job = repo.get_job(job_id)
+    assert job["completed_count"] == 3
+    assert job["status"] == JOB_COMPLETED
+
+
+async def test_local_worker_path_runs_whole_job_in_one_pass(
+    repo, settings, monkeypatch
+):
+    # chunk_index=None is how the local worker invokes run_job: no SQS fan-out,
+    # so one call must process every key and complete the job.
+    monkeypatch.setattr(enricher, "ENRICHMENT_CHUNK_SIZE", 2)
+    monkeypatch.setattr(jobs, "ENRICHMENT_CHUNK_SIZE", 2)
+    keys = ["steam_1", "steam_2", "steam_3", "steam_4", "steam_5"]
+    _seed_done_games(repo, keys)
+    job_id = create_enrichment_job(repo, _RecordingQueue(), keys)
+
+    await run_job(job_id, repo, settings=settings)
+
+    job = repo.get_job(job_id)
+    assert job["status"] == JOB_COMPLETED
+    assert job["completed_count"] == 5

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -33,6 +33,7 @@ def _job(repo, **overrides):
         "release_keys": ["steam_1", "steam_2"],
         "total": 2,
         "completed_count": 0,
+        "chunk_progress": {},
     }
     job.update(overrides)
     repo.put_job(job)
@@ -119,14 +120,24 @@ def test_get_active_job_self_heals_stale(repo):
     assert repo.get_job("dead")["status"] == JOB_FAILED
 
 
-def test_set_job_progress_is_absolute_and_idempotent(repo):
-    _job(repo, job_id="j1", completed_count=0)
-    repo.set_job_progress("j1", 1)
-    repo.set_job_progress("j1", 2)
-    # A redelivered run replays the same values; the count must not climb past
-    # what it sets, unlike an atomic increment (see #131).
-    repo.set_job_progress("j1", 1)
-    repo.set_job_progress("j1", 2)
+def test_set_chunk_progress_is_absolute_and_idempotent(repo):
+    _job(repo, job_id="j1", total=4)
+    repo.set_chunk_progress("j1", "0", 1)
+    repo.set_chunk_progress("j1", "0", 2)
+    # A redelivered run replays the same values; a chunk's count must not climb
+    # past what it sets, unlike an atomic increment (see #131).
+    repo.set_chunk_progress("j1", "0", 1)
+    repo.set_chunk_progress("j1", "0", 2)
     job = repo.get_job("j1")
     assert job["completed_count"] == 2
     assert job["updated_at"]
+
+
+def test_completed_count_sums_chunks_without_clobbering(repo):
+    # Parallel chunks write distinct map keys, so their progress adds up instead
+    # of one overwriting the other.
+    _job(repo, job_id="j1", total=4)
+    repo.set_chunk_progress("j1", "0", 2)
+    progress = repo.set_chunk_progress("j1", "1", 2)
+    assert progress == {"0": 2, "1": 2}
+    assert repo.get_job("j1")["completed_count"] == 4

--- a/tests/test_refresh_igdb.py
+++ b/tests/test_refresh_igdb.py
@@ -76,3 +76,28 @@ def test_refresh_missing_with_nothing_to_do_creates_no_job(repo):
         assert client.post("/games/refresh-igdb").status_code == 200
 
     assert repo.get_active_job() is None
+
+
+def test_refresh_all_marks_every_game_pending(repo):
+    _game(repo, "steam_1", ENRICHMENT_DONE)
+    _game(repo, "gog_2", ENRICHMENT_NOT_FOUND)
+    _game(repo, "steam_3", ENRICHMENT_DONE)
+    for client in _client(repo):
+        assert client.post("/games/refresh-igdb-all").status_code == 200
+
+    # Every game is flipped to pending so the enricher re-fetches all of them,
+    # not just the ones that were unset/pending before.
+    for rk in ("steam_1", "gog_2", "steam_3"):
+        assert repo.get_game(rk)["enrichment_status"] == ENRICHMENT_PENDING
+
+
+def test_refresh_all_queues_every_game(repo):
+    _game(repo, "steam_1", ENRICHMENT_DONE)
+    _game(repo, "gog_2", ENRICHMENT_DONE)
+    for client in _client(repo):
+        assert client.post("/games/refresh-igdb-all").status_code == 200
+
+    job = repo.get_active_job()
+    assert job is not None
+    assert sorted(job["release_keys"]) == ["gog_2", "steam_1"]
+    assert job["total"] == 2


### PR DESCRIPTION
## Problem

Investigating why a full IGDB refresh showed **1435** in the progress bar while the library listed **2562** games, I traced the live job through CloudWatch. The enricher enqueued **every release key as a single SQS message**, so one Lambda invocation had to enrich the whole library:

- The observed job ran **900,000 ms → `Status: timeout`** (the 15-min Lambda wall) after ~466 games, and only finished because SQS **redelivered** it for a second ~8-min run.
- `completed_count` was stuck at **466/1435** because absolute progress didn't survive the timeout + redelivery.
- A genuine 2954-game **"Refresh all IGDB"** would need ~6 fifteen-minute slices but `maxReceiveCount` is 3 — so it would exhaust retries and land in the **DLQ with games left unenriched**.

(The 2562 vs 1435 gap itself was expected — 2562 is distinct titles; the job was the pending/stale subset. The real bug is that even that job couldn't complete cleanly.)

## Fix

**Chunk each job into fixed-size batches** (`ENRICHMENT_CHUNK_SIZE = 200`), one SQS message per chunk, so every invocation processes only its slice and finishes well inside the timeout; SQS fans chunks out across invocations.

- Progress is tracked per chunk in a `chunk_progress` map — each chunk writes its **own key**, so parallel chunks don't clobber each other, and per-chunk writes stay **absolute** (preserves the #131 idempotency guarantee across redelivery). `completed_count` is derived from the sum.
- The job is marked complete when the chunk that accounts for the final keys observes the sum reaching `total`. Keys needing no work (missing/already-enriched) still count, so the bar reaches 100%.
- **Cap the SQS event source at `max_concurrency=2`** so the fan-out doesn't multiply per-invocation IGDB rate limiters into a global throttle (which would surface as spurious `not_found`s).

**Also fixed `Refresh all IGDB` itself:** it re-fetched each game with a per-row `get_game` before re-stamping (≈2× the round-trips) in a serial loop inside the web request. It now re-stamps directly from the scan results via a batched `mark_games_pending`.

The **local worker** still runs whole jobs in one pass (no SQS locally) and now survives a failing job instead of crashing the poll loop.

## Tests

- `tests/test_enricher_chunking.py` (new): per-chunk fan-out on creation, chunk slicing, completion only after the last chunk, redelivery not inflating progress, and the local-worker whole-job path.
- `tests/test_jobs.py`: replaced the `set_job_progress` test with `set_chunk_progress` idempotency + non-clobbering coverage.
- `tests/test_refresh_igdb.py`: added `Refresh all` marks-every-game-pending and queues-every-game coverage.
- `just check` green: black, flake8, mypy, 174 tests. CDK stack synthesis verified.

## Follow-up (not in this PR)

The automatic staleness path (`stale_release_keys`) queues stale-but-`done` games, but the enricher only re-fetches unset/pending games — so that path still can't refresh already-enriched games that have aged past `igdb_stale_days`. Worth flipping those to `pending` like the refresh buttons do, in a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)