### PR TITLE
Relabel 'Include platforms' as 'Platforms'

### DIFF
--- a/src/gamatrix/templates/default/games.html.jinja
+++ b/src/gamatrix/templates/default/games.html.jinja
@@ -67,7 +67,7 @@
     </fieldset>
 
     <fieldset class="filter-group">
-        <legend><input type="checkbox" class="toggle-all" aria-label="Include all platforms"> Include platforms</legend>
+        <legend><input type="checkbox" class="toggle-all" aria-label="Include all platforms"> Platforms</legend>
         <div class="platform-grid">
             {% for p in platforms %}
             <label><input type="checkbox" name="include" value="{{ p }}"

--- a/src/gamatrix/templates/default/preferences.html.jinja
+++ b/src/gamatrix/templates/default/preferences.html.jinja
@@ -140,7 +140,7 @@ function applyDisplayMode() {
     </fieldset>
 
     <fieldset class="filter-group">
-        <legend><input type="checkbox" class="toggle-all" aria-label="Include all platforms"> Include platforms</legend>
+        <legend><input type="checkbox" class="toggle-all" aria-label="Include all platforms"> Platforms</legend>
         <div class="platform-grid">
             {% for p in platforms %}
             <label><input type="checkbox" name="include" value="{{ p }}"

--- a/src/gamatrix/templates/modern/games.html.jinja
+++ b/src/gamatrix/templates/modern/games.html.jinja
@@ -67,7 +67,7 @@
     </fieldset>
 
     <fieldset class="filter-group">
-        <legend><input type="checkbox" class="toggle-all" aria-label="Include all platforms"> Include platforms</legend>
+        <legend><input type="checkbox" class="toggle-all" aria-label="Include all platforms"> Platforms</legend>
         <div class="platform-grid">
             {% for p in platforms %}
             <label><input type="checkbox" name="include" value="{{ p }}"

--- a/src/gamatrix/templates/modern/preferences.html.jinja
+++ b/src/gamatrix/templates/modern/preferences.html.jinja
@@ -140,7 +140,7 @@ function applyDisplayMode() {
     </fieldset>
 
     <fieldset class="filter-group">
-        <legend><input type="checkbox" class="toggle-all" aria-label="Include all platforms"> Include platforms</legend>
+        <legend><input type="checkbox" class="toggle-all" aria-label="Include all platforms"> Platforms</legend>
         <div class="platform-grid">
             {% for p in platforms %}
             <label><input type="checkbox" name="include" value="{{ p }}"


### PR DESCRIPTION
## What

This updates the `Include platforms` label in the control panel to `Platforms`. The current name comes from https://github.com/eniklas/gamatrix/pull/177 which inverted the list from exclude to include. But, include is implied so it's a little awkward now.

## How

<!-- Notable implementation details, trade-offs, or follow-ups. -->

## Checklist

- [x] PR checks pass
- [ ] Tests added/updated for the change
- [ ] Version label applied if this is more than a patch (see below)

## Versioning

**You don't need to bump the version manually.** When this PR merges to `master`,
a [GitHub Action](.github/workflows/version.yml) reads the latest semver tag,
computes the next one, and tags the merge commit. The package version is derived
from that tag by setuptools_scm — nothing is hardcoded in `pyproject.toml`.

The bump level is controlled by labels on this PR:

| Label on PR          | Result            | Example         |
| -------------------- | ----------------- | --------------- |
| _(none)_             | patch bump        | `2.0.1 → 2.0.2` |
| `new minor version`  | minor bump        | `2.0.1 → 2.1.0` |
| `new major version`  | major bump        | `2.0.1 → 3.0.0` |

Apply at most one of the version labels. If both are present, `new major version`
wins.
